### PR TITLE
 [TRNT-3844] Add initial Helm chart

### DIFF
--- a/helm/trento-mcp-server/templates/mcp-server-deployment.yaml
+++ b/helm/trento-mcp-server/templates/mcp-server-deployment.yaml
@@ -7,20 +7,20 @@ metadata:
   name: {{ include "trento-mcp-server.fullname" . }}-mcp-server
   namespace: {{ .Release.Namespace }}
   labels:
-    app: mcp-server-trento
+    app: trento-mcp-server
   {{- include "trento-mcp-server.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.mcpServer.replicas }}
   selector:
     matchLabels:
-      app: mcp-server-trento
+      app: trento-mcp-server
     {{- include "trento-mcp-server.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/mcp-server-configmap.yaml") . | sha256sum }}
       labels:
-        app: mcp-server-trento
+        app: trento-mcp-server
       {{- include "trento-mcp-server.selectorLabels" . | nindent 8 }}
     spec:
       containers:
@@ -29,17 +29,17 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.mcpServer.image.repository }}:{{ .Values.mcpServer.image.tag | default .Chart.AppVersion }}
-        name: mcp-server-trento
+        name: trento-mcp-server
         ports:
         - containerPort: 8080
           name: http
         resources: {{- toYaml .Values.mcpServer.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /app/api
-          name: mcp-server-openapi-volume
+          name: trento-mcp-server-openapi-volume
           readOnly: true
       imagePullSecrets: []
       volumes:
       - configMap:
           name: {{ include "trento-mcp-server.fullname" . }}-mcp-server
-        name: mcp-server-openapi-volume
+        name: trento-mcp-server-openapi-volume

--- a/helm/trento-mcp-server/templates/mcp-server-service.yaml
+++ b/helm/trento-mcp-server/templates/mcp-server-service.yaml
@@ -7,12 +7,12 @@ metadata:
   name: {{ include "trento-mcp-server.fullname" . }}-mcp-server
   namespace: {{ .Release.Namespace }}
   labels:
-    app: mcp-server-trento
+    app: trento-mcp-server
   {{- include "trento-mcp-server.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.mcpServer.type }}
   selector:
-    app: mcp-server-trento
+    app: trento-mcp-server
     {{- include "trento-mcp-server.selectorLabels" . | nindent 4 }}
   ports:
   {{- .Values.mcpServer.ports | toYaml | nindent 2 }}


### PR DESCRIPTION
# Description

_(This PR supersedes https://github.com/trento-project/mcp-server/pull/2, which was unintentionally merged)_

This PR, following up on #1, adds the initial code for the Helm chart for the MCP server. This is just the initial version for these early stages of development. We might need to move the files to the [trento-project/helm-charts ](https://github.com/trento-project/helm-charts) repository in the future.

The Helm chart was autogenerated from the manifests using [Helmify](https://github.com/arttor/helmify), so, in the future, we will need to polish it up.

Besides, the Helm chart contains autogenerated `values.schema.json` and  `questions.yml` files, so that it can be consumed by UIs.

Related to #TRNT-3844.

## How was this tested?

N/A, this PR is mostly for sharing the current prototype we have. Not ready for production usage yet.

