### PR TITLE
[TRNT-3853] Use `asdf` versions in the scripts and CI

### DIFF
--- a/.github/workflows/pipeline-definition.yaml
+++ b/.github/workflows/pipeline-definition.yaml
@@ -14,10 +14,6 @@ env:
   IMG_PREFIX_FOR_FORKS: "your-registry-username/"
   IMAGES_TO_PUSH: "trento-mcp-server"
 
-  # Versions
-  GOLANG_VERSION: "1.24.4" # See https://go.dev/dl/, must be aligned with "toolchain goX.X.X" in go.mod
-  HELM_VERSION: "v3.18.6" # See https://github.com/helm/helm/releases
-
 jobs:
   # Setup the environment and set outputs
   setup:
@@ -25,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       golang_version: ${{ steps.set-outputs.outputs.golang_version }}
+      helm_version: ${{ steps.set-outputs.outputs.helm_version }}
       img_modifier: ${{ steps.set-outputs.outputs.img_modifier }}
       img_prefix: ${{ steps.set-outputs.outputs.img_prefix }}
       img_dev_tag: ${{ steps.set-outputs.outputs.img_dev_tag }}
@@ -33,6 +30,8 @@ jobs:
       triggered_from_fork: ${{ steps.set-outputs.outputs.triggered_from_fork }}
       gh_username: ${{ steps.set-outputs.outputs.gh_username }}
     steps:
+      - uses: actions/checkout@v5
+        name: Checkout
       - name: Show GitHub event
         env:
           EVENT_CONTEXT: ${{ toJSON(github.event) }}
@@ -48,6 +47,11 @@ jobs:
           PR_SOURCE_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -euo pipefail
+
+          # Read versions from .tool-versions file (no fallbacks - must exist)
+          GOLANG_VERSION=$(grep '^golang' .tool-versions | cut -d' ' -f2)
+          HELM_VERSION="v$(grep '^helm' .tool-versions | cut -d' ' -f2)"
+
           if [[ "${GITHUB_REPOSITORY}" == "${TRENTO_REPO}" ]]; then
             echo "img_prefix=${IMG_PREFIX}" >> $GITHUB_OUTPUT
           else
@@ -77,6 +81,7 @@ jobs:
           fi
 
           echo "golang_version=${GOLANG_VERSION}" >> $GITHUB_OUTPUT
+          echo "helm_version=${HELM_VERSION}" >> $GITHUB_OUTPUT
           echo "img_modifier=${IMG_MODIFIER}" >> $GITHUB_OUTPUT
           echo "img_dev_tag=${IMG_DEV_TAG}" >> $GITHUB_OUTPUT
           # Set it directly in GitHub repository variables:
@@ -85,6 +90,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "GOLANG_VERSION: ${{steps.set-outputs.outputs.golang_version}}"
+          echo "HELM_VERSION: ${{steps.set-outputs.outputs.helm_version}}"
           echo "IMG_MODIFIER: ${{steps.set-outputs.outputs.img_modifier}}"
           echo "IMG_PREFIX: ${{steps.set-outputs.outputs.img_prefix}}"
           echo "IMG_DEV_TAG: ${{steps.set-outputs.outputs.img_dev_tag}}"
@@ -106,7 +112,7 @@ jobs:
       - uses: actions/setup-go@v5
         name: Set up Go
         with:
-          go-version: ${{ env.GOLANG_VERSION }}
+          go-version: ${{ needs.setup.outputs.golang_version }}
       - name: Run go unit tests
         run: make test
 
@@ -122,6 +128,7 @@ jobs:
       - name: Install Helm binary
         run: |
           set -euo pipefail
+          HELM_VERSION="${{ needs.setup.outputs.helm_version }}"
           echo "Installing Helm ${HELM_VERSION}"
           pushd /tmp
           wget "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,7 @@
+golang 1.25.0
+golangci-lint 2.4.0
+helm 3.18.6
+kube-score 1.20.0
+make 4.4.1
+shellcheck 0.11.0
+yamllint 1.37.1

--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,11 @@ HELM ?= $(LOCALBIN)/helm-$(HELM_VERSION)
 KUBE_SCORE ?= $(LOCALBIN)/kube-score-$(KUBE_SCORE_VERSION)
 
 ## Tool Versions
-GOLANGCI_LINT_VERSION ?= v2.4.0 # See https://github.com/golangci/golangci-lint/releases
-HELM_VERSION ?= v3.18.6 # See https://github.com/helm/helm/releases
-KUBE_SCORE_VERSION ?= v1.20.0 # See https://github.com/zegl/kube-score/releases
+TOOL_VERSIONS_FILE := ${CURDIR}/.tool-versions
+
+GOLANGCI_LINT_VERSION ?= v$(shell grep '^golangci-lint' $(TOOL_VERSIONS_FILE) | cut -d' ' -f2) # See https://github.com/golangci/golangci-lint/releases
+HELM_VERSION ?= v$(shell grep '^helm' $(TOOL_VERSIONS_FILE) | cut -d' ' -f2) # See https://github.com/helm/helm/releases
+KUBE_SCORE_VERSION ?= v$(shell grep '^kube-score' $(TOOL_VERSIONS_FILE) | cut -d' ' -f2) # See https://github.com/zegl/kube-score/releases
 
 .PHONY: install-tools
 install-tools: golangci-lint helm kube-score ## Download all the required tools.


### PR DESCRIPTION
# Description

_Still WIP_


Addressing this comment:

**suggestion:** not sure we already touched this, however what do you about using [asdf](https://asdf-vm.com/) as we do in other repos?

_Originally posted by @nelsonkopliku in https://github.com/trento-project/mcp-server/pull/14#discussion_r2317960755_
            


Related #TRNT-3853

## How was this tested?

IRL testing, CI

