### PR TITLE
[TRNT-3845] Update API docs

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1,361 +1,10804 @@
 {
+  "openapi": "3.0.0",
+  "info": {
+    "contact": {
+      "email": "trento-project@suse.com",
+      "name": "Trento Project",
+      "url": "https://www.trento-project.io"
+    },
+    "description": "Easing your life in administering SAP application. Trento is an open-source web application, built by SUSE, to enhance day-2 operations of SAP workloads. It can be used to proactively prevent infrastructural issues by diagnosing common issues, validate systems configuration against best practices, and remove toil from routine OS tasks on mission-critical systems.",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "title": "Trento",
+    "version": "2.5.0"
+  },
+  "servers": [
+    {
+      "description": "This is the Trento demo server, provided for testing and demonstration purposes.",
+      "url": "https://demo.trento-project.io",
+      "variables": {}
+    }
+  ],
+  "tags": [
+    {
+      "description": "Handles communication with agents and collects data from managed systems in the infrastructure.",
+      "name": "Agent",
+      "x-displayName": "Agent"
+    },
+    {
+      "description": "Manages authentication, user login, and session lifecycle for secure access to the platform.",
+      "name": "Auth",
+      "x-displayName": "Auth"
+    },
+    {
+      "description": "Provides monitoring and visualization of host performance metrics and system health over time.",
+      "name": "Charts",
+      "x-displayName": "Charts"
+    },
+    {
+      "description": "Offers features for running automated checks and validations to ensure system compliance and reliability.",
+      "name": "Checks",
+      "x-displayName": "Checks"
+    },
+    {
+      "description": "Exposes endpoints as tools for Model Context Protocol (MCP) integration, enabling those endpoints to be consumed by any LLM.",
+      "name": "MCP",
+      "x-displayName": "MCP"
+    },
+    {
+      "description": "Supports a variety of operations for SAP systems and infrastructure, including resource management and workflow execution.",
+      "name": "Operations",
+      "x-displayName": "Operations"
+    },
+    {
+      "description": "Gives access to core Trento Platform capabilities and general platform information for users and administrators.",
+      "name": "Platform",
+      "x-displayName": "Platform"
+    },
+    {
+      "description": "Allows users to view and update their personal profile information and preferences within the platform.",
+      "name": "Profile",
+      "x-displayName": "Profile"
+    },
+    {
+      "description": "Enables configuration and management of platform-wide settings, including integrations and environment options.",
+      "name": "Settings",
+      "x-displayName": "Settings"
+    },
+    {
+      "description": "Facilitates resource tagging and organization to improve searchability and logical grouping of assets.",
+      "name": "Tags",
+      "x-displayName": "Tags"
+    },
+    {
+      "description": "Provides access to information and management features for the discovered target infrastructure resources.",
+      "name": "Target Infrastructure",
+      "x-displayName": "Target Infrastructure"
+    },
+    {
+      "description": "Handles user account creation, permissions, and administrative controls for managing platform users.",
+      "name": "User Management",
+      "x-displayName": "User Management"
+    },
+    {
+      "description": "Endpoints for managing and executing checks, including configuration and results retrieval.",
+      "name": "Wanda Checks",
+      "x-displayName": "Wanda Checks"
+    },
+    {
+      "description": "Endpoints for accessing Wanda Platform features.",
+      "name": "Wanda Platform",
+      "x-displayName": "Wanda Platform"
+    }
+  ],
+  "paths": {
+    "/api/healthz": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves the overall health status of the Trento Web platform, including database connectivity and service availability. Use this endpoint to verify system health for diagnostics and monitoring purposes.",
+        "operationId": "TrentoWeb.HealthController.health",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_Health"
+                }
+              }
+            },
+            "description": "A successful health check response providing the current status of the Trento Web platform, including database connectivity and service availability for diagnostics and monitoring."
+          }
+        },
+        "security": [],
+        "summary": "Trento Web health.",
+        "tags": [
+          "Platform"
+        ]
+      }
+    },
+    "/api/public_keys": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves all uploaded public keys for secure authentication and integration, supporting infrastructure security and access control.",
+        "operationId": "TrentoWeb.V1.SettingsController.get_public_keys",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_PublicKeys"
+                }
+              }
+            },
+            "description": "A comprehensive list of all uploaded public keys for secure authentication and integration."
+          }
+        },
+        "summary": "Get uploaded public keys.",
+        "tags": [
+          "Settings",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/readyz": {
+      "get": {
+        "callbacks": {},
+        "description": "Performs a readiness check to determine if the Trento Web application is operational and able to serve requests. This endpoint is useful for monitoring and automation systems.",
+        "operationId": "TrentoWeb.HealthController.ready",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_Ready"
+                }
+              }
+            },
+            "description": "A successful readiness check indicating that the Trento Web application is operational and ready to serve requests. Useful for monitoring and automation systems."
+          }
+        },
+        "security": [],
+        "summary": "Trento Web ready.",
+        "tags": [
+          "Platform"
+        ]
+      }
+    },
+    "/api/session": {
+      "post": {
+        "callbacks": {},
+        "description": "Retrieve the access and refresh token for api interactions, returns two jwt tokens.",
+        "operationId": "TrentoWeb.SessionController.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "description": "User login credentials schema.",
+                "example": {
+                  "password": "thepassword",
+                  "username": "admin"
+                },
+                "properties": {
+                  "password": {
+                    "example": "thepassword",
+                    "type": "string"
+                  },
+                  "totp_code": {
+                    "example": "123456",
+                    "type": "string"
+                  },
+                  "username": {
+                    "example": "admin",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Login request containing user credentials for authentication and token issuance.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Successful authentication returns access and refresh tokens for secure API usage. The response includes token expiration details and is suitable for session management.",
+                  "example": {
+                    "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A",
+                    "expires_in": 600,
+                    "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A"
+                  },
+                  "properties": {
+                    "access_token": {
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "type": "string"
+                    },
+                    "expires_in": {
+                      "example": 600,
+                      "type": "integer"
+                    },
+                    "refresh_token": {
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication result with access and refresh tokens for secure API usage."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_Unauthorized"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that access to the requested operation is denied due to missing or invalid authentication credentials."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "security": [],
+        "summary": "Platform login.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/session/refresh": {
+      "post": {
+        "callbacks": {},
+        "description": "Generate a new access token from a valid refresh token.",
+        "operationId": "TrentoWeb.SessionController.refresh",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Refresh token credentials for getting new access token.",
+                "example": {
+                  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A"
+                },
+                "properties": {
+                  "refresh_token": {
+                    "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Request containing refresh token for obtaining new access credentials.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "A valid refresh token returns new access credentials for continued secure API usage. The response includes updated token expiration information for session management.",
+                  "example": {
+                    "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A",
+                    "expires_in": 600
+                  },
+                  "properties": {
+                    "access_token": {
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "type": "string"
+                    },
+                    "expires_in": {
+                      "example": 600,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Refreshed authentication result with new access token for continued secure API usage."
+          }
+        },
+        "security": [],
+        "summary": "Platform access token refresh.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/session/{provider}/callback": {
+      "post": {
+        "callbacks": {},
+        "description": "Authenticate against an external authentication provider.",
+        "operationId": "TrentoWeb.SessionController.callback",
+        "parameters": [
+          {
+            "description": "Identity provider name.",
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "example": "oauth2_local",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "User identity provider enrollment credentials with authorization code.",
+                "example": {
+                  "code": "kyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYt",
+                  "session_state": "frHteBttgtW8706m7nqYC6ruYt"
+                },
+                "properties": {
+                  "code": {
+                    "example": "kyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYt",
+                    "type": "string"
+                  },
+                  "session_state": {
+                    "example": "frHteBttgtW8706m7nqYC6ruYt",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "session_state"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "description": "Request containing identity provider credentials and authorization code for external authentication.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Successful authentication with an external identity provider returns access and refresh tokens for secure platform usage. The response is suitable for federated identity management and session handling.",
+                  "example": {
+                    "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A",
+                    "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A"
+                  },
+                  "properties": {
+                    "access_token": {
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "type": "string"
+                    },
+                    "refresh_token": {
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication result from external identity provider with access and refresh tokens."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_Unauthorized"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that access to the requested operation is denied due to missing or invalid authentication credentials."
+          }
+        },
+        "security": [],
+        "summary": "Platform external IDP callback.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/session/{provider}/saml_callback": {
+      "get": {
+        "callbacks": {},
+        "description": "Authenticates the user against an external authentication provider using SAML, enabling single sign-on and federated identity management for secure platform access.",
+        "operationId": "TrentoWeb.SessionController.saml_callback",
+        "parameters": [
+          {
+            "description": "The name of the SAML identity provider to use for authentication. This value should match a configured provider.",
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "example": "saml",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Authentication using SAML returns access and refresh tokens for secure platform access. The response supports single sign-on and federated identity management for user sessions.",
+                  "example": {
+                    "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A",
+                    "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A"
+                  },
+                  "properties": {
+                    "access_token": {
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "type": "string"
+                    },
+                    "refresh_token": {
+                      "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication result using SAML identity provider with access and refresh tokens for platform access."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_Unauthorized"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that access to the requested operation is denied due to missing or invalid authentication credentials."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "security": [],
+        "summary": "Platform external SAML IDP callback.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/v1/clusters": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a comprehensive list of all Pacemaker Clusters discovered on the target infrastructure, supporting monitoring and management tasks for administrators.",
+        "operationId": "TrentoWeb.V1.ClusterController.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_PacemakerClustersCollection"
+                }
+              }
+            },
+            "description": "Comprehensive list of all Pacemaker Clusters discovered on the target infrastructure for monitoring and management."
+          }
+        },
+        "summary": "List Pacemaker Clusters.",
+        "tags": [
+          "Target Infrastructure"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/exporters_status": {
+      "get": {
+        "callbacks": {},
+        "description": "Returns the status of Prometheus exporters for a specific host, identified by its unique ID, supporting health monitoring and diagnostics for infrastructure components.",
+        "operationId": "TrentoWeb.V1.PrometheusController.exporters_status",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host for which Prometheus exporter status is requested. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_PrometheusExporterStatus"
+                }
+              }
+            },
+            "description": "Status information for Prometheus exporters on the specified host, supporting health monitoring and diagnostics."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          }
+        },
+        "summary": "Get prometheus exporters status.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/clusters/{cluster_id}/checks": {
+      "post": {
+        "callbacks": {},
+        "description": "Allows users to select which Checks are eligible for execution on a specific cluster within the target infrastructure, supporting custom validation workflows.",
+        "operationId": "TrentoWeb.V1.ClusterController.select_checks",
+        "parameters": [
+          {
+            "description": "Unique identifier of the cluster for which Checks selection is being performed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "cluster_id",
+            "required": true,
+            "schema": {
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_ChecksSelectionRequest"
+              }
+            }
+          },
+          "description": "Checks Selection.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Selected checks for the cluster have been successfully collected and are ready for execution."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Select Checks for a Cluster.",
+        "tags": [
+          "Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/sap_systems/{id}/operations/{operation}": {
+      "post": {
+        "callbacks": {},
+        "description": "Submits a request to perform a specific operation on a SAP system, such as restart or configuration change, supporting automated infrastructure management.",
+        "operationId": "TrentoWeb.V1.SapSystemController.request_operation",
+        "parameters": [
+          {
+            "description": "Unique identifier of the SAP system on which the operation will be performed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the type of operation to be performed on the SAP system, such as restart or configuration change.",
+            "in": "path",
+            "name": "operation",
+            "required": true,
+            "schema": {
+              "example": "restart",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_SapSystemOperationParams"
+              }
+            }
+          },
+          "description": "Request containing parameters for the specified SAP system operation, such as restart or configuration change.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_OperationAccepted"
+                }
+              }
+            },
+            "description": "A detailed response indicating that the requested operation has been accepted for processing, including confirmation and tracking information."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Request operation for a SAP system.",
+        "tags": [
+          "Operations"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/api_key": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves the current settings for API key generation, including expiration and configuration details, supporting secure access management.",
+        "operationId": "TrentoWeb.V1.SettingsController.get_api_key_settings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_ApiKeySettings"
+                }
+              }
+            },
+            "description": "A comprehensive set of API key settings and configuration details for secure access management."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          }
+        },
+        "summary": "Get API key settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "description": "Updates the configuration for API key generation, allowing administrators to change expiration and security settings for API access.",
+        "operationId": "TrentoWeb.V1.SettingsController.update_api_key_settings",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_ApiKeySettingsUpdateRequest"
+              }
+            }
+          },
+          "description": "Request body containing updated API key settings and expiration configuration for secure access management.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_ApiKeySettings"
+                }
+              }
+            },
+            "description": "API key settings have been successfully updated and saved, including expiration and security configuration."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Updates the API key settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/charts/hosts/{id}/cpu": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves detailed CPU usage statistics for a specific host over a defined time interval, enabling performance analysis and resource monitoring for infrastructure management.",
+        "operationId": "TrentoWeb.V1.ChartController.host_cpu",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host for which CPU usage data is requested. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Unique identifier of the host for which CPU usage data is requested. This value must be a valid UUID string.",
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the start of the time interval for the CPU usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T10:00:00Z).",
+            "in": "query",
+            "name": "from",
+            "required": true,
+            "schema": {
+              "description": "Specifies the start of the time interval for the CPU usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T10:00:00Z).",
+              "example": "2024-01-15T10:00:00Z",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the end of the time interval for the CPU usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T12:00:00Z).",
+            "in": "query",
+            "name": "to",
+            "required": true,
+            "schema": {
+              "description": "Specifies the end of the time interval for the CPU usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T12:00:00Z).",
+              "example": "2024-01-15T12:00:00Z",
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_HostCpuChart"
+                }
+              }
+            },
+            "description": "Detailed CPU usage statistics for the host over a defined time interval, supporting performance analysis and monitoring."
+          }
+        },
+        "summary": "Get a CPU chart of a host.",
+        "tags": [
+          "Charts"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/checks": {
+      "post": {
+        "callbacks": {},
+        "description": "Allows users to select which Checks are eligible for execution on a specific host within the target infrastructure, supporting custom validation workflows.",
+        "operationId": "TrentoWeb.V1.HostController.select_checks",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host for which Checks selection is being performed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_ChecksSelectionRequest"
+              }
+            }
+          },
+          "description": "Checks Selection.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Selected checks for the host have been successfully collected and are ready for execution."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Select Checks for a Host.",
+        "tags": [
+          "Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/databases/{id}/hosts/{host_id}/instances/{instance_number}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes the specified database instance from the system if it is no longer present, supporting infrastructure cleanup and resource management.",
+        "operationId": "TrentoWeb.V1.DatabaseController.delete_database_instance",
+        "parameters": [
+          {
+            "description": "Unique identifier of the database instance to be deleted. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Unique identifier of the host associated with the database instance. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The instance number of the database to be deleted, used to uniquely identify the specific database instance within the host.",
+            "in": "path",
+            "name": "instance_number",
+            "required": true,
+            "schema": {
+              "example": "10",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The database instance has been deregistered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Delete database instance.",
+        "tags": [
+          "Target Infrastructure"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a comprehensive list of all users currently registered in the system, supporting user management and administrative tasks.",
+        "operationId": "TrentoWeb.V1.UsersController.index",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserCollection"
+                }
+              }
+            },
+            "description": "Comprehensive list of all users currently registered in the system for user management and administrative tasks."
+          }
+        },
+        "summary": "Gets the list of users in the system.",
+        "tags": [
+          "User Management",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "Creates a new user account in the system, supporting onboarding and user management for administrators.",
+        "operationId": "TrentoWeb.V1.UsersController.create",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_UserCreationRequest"
+              }
+            }
+          },
+          "description": "Request containing new user account information for onboarding and user management.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserItem"
+                }
+              }
+            },
+            "description": "User account created successfully, returning the new user details for management and review."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Create a new User.",
+        "tags": [
+          "User Management"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/clusters/{id}/operations/{operation}": {
+      "post": {
+        "callbacks": {},
+        "description": "Submits a request to perform a specific operation on a cluster, such as maintenance or configuration changes, supporting automated infrastructure management.",
+        "operationId": "TrentoWeb.V1.ClusterController.request_operation",
+        "parameters": [
+          {
+            "description": "Unique identifier of the cluster on which the operation will be performed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the type of operation to be performed on the cluster, such as maintenance or configuration change.",
+            "in": "path",
+            "name": "operation",
+            "required": true,
+            "schema": {
+              "example": "cluster_maintenance_change",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_ClusterOperationParams"
+              }
+            }
+          },
+          "description": "Request containing parameters for the specified cluster operation.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_OperationAccepted"
+                }
+              }
+            },
+            "description": "A detailed response indicating that the requested operation has been accepted for processing, including confirmation and tracking information."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Request operation for a Cluster.",
+        "tags": [
+          "Operations"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/clusters/{id}/hosts/{host_id}/operations/{operation}": {
+      "post": {
+        "callbacks": {},
+        "description": "Submits a request to perform a specific operation on a host within a cluster, supporting targeted maintenance or configuration changes for individual hosts.",
+        "operationId": "TrentoWeb.V1.ClusterController.request_host_operation",
+        "parameters": [
+          {
+            "description": "Unique identifier of the cluster containing the host. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Unique identifier of the host within the cluster on which the operation will be performed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the type of operation to be performed on the cluster's host, such as enabling or disabling pacemaker services.",
+            "in": "path",
+            "name": "operation",
+            "required": true,
+            "schema": {
+              "example": "pacemaker_enable",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_OperationAccepted"
+                }
+              }
+            },
+            "description": "A detailed response indicating that the requested operation has been accepted for processing, including confirmation and tracking information."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Request operation for a Cluster host.",
+        "tags": [
+          "Operations"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/about": {
+      "get": {
+        "callbacks": {},
+        "description": "Returns detailed general information about the current Platform installation, including version and subscription details, to help users and administrators understand the system environment.",
+        "operationId": "TrentoWeb.V1.AboutController.info",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_GeneralInformation"
+                }
+              }
+            },
+            "description": "Detailed general information about the platform installation, including version and subscription details."
+          }
+        },
+        "summary": "Platform General Information.",
+        "tags": [
+          "Platform",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/prometheus/targets": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a list of Prometheus exporter targets in the Http Discovery format, supporting monitoring and integration with Prometheus for infrastructure observability.",
+        "operationId": "TrentoWeb.V1.PrometheusController.targets",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_HttpSTDTargetList"
+                }
+              }
+            },
+            "description": "Comprehensive list of Prometheus exporter targets in Http Discovery format for infrastructure monitoring and integration."
+          }
+        },
+        "summary": "Get Prometheus exporters targets.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/tags/{value}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes a tag from the specified host, supporting resource management and cleanup for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.remove_tag_from_host",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host from which the tag will be removed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The value of the tag to be removed from the host.",
+            "in": "path",
+            "name": "value",
+            "required": true,
+            "schema": {
+              "example": "production",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The tag has been removed from the host."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Remove tag from host.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes a host agent from Trento, supporting infrastructure cleanup and resource management for administrators.",
+        "operationId": "TrentoWeb.V1.HostController.delete",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host to be deregistered. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The host has been deregistered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Deregister a host.",
+        "tags": [
+          "Target Infrastructure"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/clusters/{id}/tags/{value}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes a tag from the specified cluster, supporting resource management and cleanup for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.remove_tag_from_cluster",
+        "parameters": [
+          {
+            "description": "Unique identifier of the cluster from which the tag will be removed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The value of the tag to be removed from the cluster.",
+            "in": "path",
+            "name": "value",
+            "required": true,
+            "schema": {
+              "example": "production",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The tag has been removed from the cluster."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Remove tag from cluster.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/clusters/{id}/tags": {
+      "post": {
+        "callbacks": {},
+        "description": "Adds a new tag to the specified cluster, supporting resource categorization and management for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.add_tag_to_cluster",
+        "parameters": [
+          {
+            "description": "Unique identifier of the cluster to which the tag will be added. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "example": {
+                  "value": "production"
+                },
+                "properties": {
+                  "value": {
+                    "example": "production",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Request containing tag value to be added to the specified cluster for resource categorization and management.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tag has been successfully added to the specified cluster, supporting resource categorization and management."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Add tag to cluster.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/profile": {
+      "get": {
+        "callbacks": {},
+        "description": "Returns the profile information of the currently authenticated user, supporting account management and personalization features.",
+        "operationId": "TrentoWeb.V1.ProfileController.show",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserProfile"
+                }
+              }
+            },
+            "description": "Profile information of the currently authenticated user, supporting account management and personalization features."
+          }
+        },
+        "summary": "Get profile.",
+        "tags": [
+          "Profile",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "description": "Updates the profile of the currently authenticated user with new information, supporting account management and personalization features.",
+        "operationId": "TrentoWeb.V1.ProfileController.update",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_UserProfileUpdateRequest"
+              }
+            }
+          },
+          "description": "Request containing updated profile information for the currently authenticated user.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserProfile"
+                }
+              }
+            },
+            "description": "Profile update was successful, returning the updated user profile information for account management."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Update the current user profile.",
+        "tags": [
+          "Profile"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/charts/hosts/{id}/memory": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves detailed memory usage statistics for a specific host over a defined time interval, supporting infrastructure monitoring and troubleshooting for system administrators.",
+        "operationId": "TrentoWeb.V1.ChartController.host_memory",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host for which memory usage data is requested. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Unique identifier of the host for which memory usage data is requested. This value must be a valid UUID string.",
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the start of the time interval for the memory usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T10:00:00Z).",
+            "in": "query",
+            "name": "from",
+            "required": true,
+            "schema": {
+              "description": "Specifies the start of the time interval for the memory usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T10:00:00Z).",
+              "example": "2024-01-15T10:00:00Z",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the end of the time interval for the memory usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T12:00:00Z).",
+            "in": "query",
+            "name": "to",
+            "required": true,
+            "schema": {
+              "description": "Specifies the end of the time interval for the memory usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T12:00:00Z).",
+              "example": "2024-01-15T12:00:00Z",
+              "format": "date-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_HostMemoryChart"
+                }
+              }
+            },
+            "description": "Detailed memory usage statistics for the host over a defined time interval, supporting infrastructure monitoring and troubleshooting."
+          }
+        },
+        "summary": "Get a Memory chart of a host.",
+        "tags": [
+          "Charts"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/activity_log": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves the current configuration for the Activity Log, including retention period and related settings, supporting compliance and audit requirements.",
+        "operationId": "TrentoWeb.V1.SettingsController.get_activity_log_settings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_ActivityLogSettings"
+                }
+              }
+            },
+            "description": "A comprehensive set of activity log settings and configuration details for compliance and audit requirements."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          }
+        },
+        "summary": "Fetches the Activity Log settings.",
+        "tags": [
+          "Settings",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "put": {
+        "callbacks": {},
+        "description": "Updates the configuration for the Activity Log, including retention period and related settings, supporting compliance and audit requirements.",
+        "operationId": "TrentoWeb.V1.SettingsController.update_activity_log_settings",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_ActivityLogSettings"
+              }
+            }
+          },
+          "description": "Request body containing updated activity log settings, including retention period and compliance configuration.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_ActivityLogSettings"
+                }
+              }
+            },
+            "description": "Activity Log settings have been successfully updated and saved, including retention period and compliance configuration."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Updates the Activity Log settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/sap_systems/{id}/hosts/{host_id}/instances/{instance_number}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes the specified application instance from the system if it is no longer present, supporting infrastructure cleanup and resource management.",
+        "operationId": "TrentoWeb.V1.SapSystemController.delete_application_instance",
+        "parameters": [
+          {
+            "description": "Unique identifier of the SAP system associated with the application instance to be deleted. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Unique identifier of the host associated with the application instance. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The instance number of the SAP application to be deleted, used to uniquely identify the specific application instance within the host.",
+            "in": "path",
+            "name": "instance_number",
+            "required": true,
+            "schema": {
+              "example": "10",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The application instance has been deregistered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Delete application instance.",
+        "tags": [
+          "Target Infrastructure"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/sap_systems/{id}/tags": {
+      "post": {
+        "callbacks": {},
+        "description": "Adds a new tag to the specified SAP system, supporting resource categorization and management for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.add_tag_to_sap_system",
+        "parameters": [
+          {
+            "description": "Unique identifier of the SAP system to which the tag will be added. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "value": {
+                    "example": "production",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Request containing tag value to be added to the specified SAP system for resource categorization and management.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tag has been successfully added to the specified SAP system, supporting resource categorization and management."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Add tag to SAP system.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/operations/{operation}": {
+      "post": {
+        "callbacks": {},
+        "description": "Submits a request to perform a specific operation on a host, such as restart or configuration change, supporting automated infrastructure management.",
+        "operationId": "TrentoWeb.V1.HostController.request_operation",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host on which the operation will be performed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the type of operation to be performed on the host, such as restart or configuration change.",
+            "in": "path",
+            "name": "operation",
+            "required": true,
+            "schema": {
+              "example": "restart",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_HostOperationParams"
+              }
+            }
+          },
+          "description": "Request containing parameters for the specified host operation.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_OperationAccepted"
+                }
+              }
+            },
+            "description": "A detailed response indicating that the requested operation has been accepted for processing, including confirmation and tracking information."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Request operation for a Host.",
+        "tags": [
+          "Operations"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/suse_manager": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes all saved credentials and configuration for SUSE Manager integration, supporting secure decommissioning and access management.",
+        "operationId": "TrentoWeb.V1.SettingsController.delete_suse_manager_settings",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "All SUSE Manager credentials and configuration have been successfully cleared from the system."
+          }
+        },
+        "summary": "Clears the SUSE Manager settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves the saved configuration and credentials for SUSE Manager integration, supporting automated software management and updates.",
+        "operationId": "TrentoWeb.V1.SettingsController.get_suse_manager_settings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_SuseManagerSettings"
+                }
+              }
+            },
+            "description": "A comprehensive set of SUSE Manager integration credentials and configuration details for automated software management."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          }
+        },
+        "summary": "Gets the SUSE Manager Settings.",
+        "tags": [
+          "Settings",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "description": "Updates the configuration and credentials for SUSE Manager integration, supporting ongoing software management and updates.",
+        "operationId": "TrentoWeb.V1.SettingsController.update_suse_manager_settings",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_UpdateSuseManagerSettingsRequest"
+              }
+            }
+          },
+          "description": "Request body containing updated SUSE Manager credentials and configuration for ongoing secure integration and software management.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_SuseManagerSettings"
+                }
+              }
+            },
+            "description": "SUSE Manager settings have been successfully updated and saved, including credentials and configuration for secure integration."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Updates the SUSE Manager settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "Saves new credentials and configuration for SUSE Manager integration, enabling secure software management and updates.",
+        "operationId": "TrentoWeb.V1.SettingsController.save_suse_manager_settings",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_SaveSuseManagerSettingsRequest"
+              }
+            }
+          },
+          "description": "Request body containing new SUSE Manager credentials and configuration for secure integration and software management.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_SuseManagerSettings"
+                }
+              }
+            },
+            "description": "SUSE Manager settings have been successfully saved, including credentials and configuration for secure integration."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Saves the SUSE Manager settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "put": {
+        "callbacks": {},
+        "description": "Updates the configuration and credentials for SUSE Manager integration, supporting ongoing software management and updates.",
+        "operationId": "TrentoWeb.V1.SettingsController.put_suse_manager_settings",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_UpdateSuseManagerSettingsRequest"
+              }
+            }
+          },
+          "description": "Request body containing updated SUSE Manager credentials and configuration for ongoing secure integration and software management.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_SuseManagerSettings"
+                }
+              }
+            },
+            "description": "SUSE Manager settings have been successfully updated and saved, including credentials and configuration for secure integration."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Updates the SUSE Manager settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/sap_systems/{id}/tags/{value}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes a tag from the specified SAP system, supporting resource management and cleanup for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.remove_tag_from_sap_system",
+        "parameters": [
+          {
+            "description": "Unique identifier of the SAP system from which the tag will be removed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The value of the tag to be removed from the SAP system.",
+            "in": "path",
+            "name": "value",
+            "required": true,
+            "schema": {
+              "example": "production",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The tag has been removed from the SAP system."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Remove tag from SAP system.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/sap_systems/health": {
+      "get": {
+        "callbacks": {},
+        "description": "Returns an aggregated health overview of all discovered SAP Systems and their components on the target infrastructure, supporting monitoring, diagnostics, and operational decision-making for administrators.",
+        "operationId": "TrentoWeb.V1.HealthOverviewController.overview",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_HealthOverview"
+                }
+              }
+            },
+            "description": "An overview of the health of the discovered SAP Systems and their components."
+          }
+        },
+        "summary": "Health overview of the discovered SAP Systems.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a comprehensive list of all hosts discovered on the target infrastructure, supporting monitoring and management tasks for administrators.",
+        "operationId": "TrentoWeb.V1.HostController.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_HostsCollection"
+                }
+              }
+            },
+            "description": "Comprehensive list of all hosts discovered on the target infrastructure for monitoring and management."
+          }
+        },
+        "summary": "List hosts.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/software_updates/errata_details/{advisory_name}": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves detailed information for a specified advisory, including CVEs, bug fixes, affected packages, and systems, supporting vulnerability management and compliance.",
+        "operationId": "TrentoWeb.V1.SUSEManagerController.errata_details",
+        "parameters": [
+          {
+            "description": "The name of the advisory for which details are being requested, such as SUSE-2025-1234.",
+            "in": "path",
+            "name": "advisory_name",
+            "required": true,
+            "schema": {
+              "example": "SUSE-2025-1234",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_ErrataDetailsResponse"
+                }
+              }
+            },
+            "description": "Detailed information about the specified advisory, including CVEs, bug fixes, affected packages, and systems."
+          }
+        },
+        "summary": "Gets the details for an advisory.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/heartbeat": {
+      "post": {
+        "callbacks": {},
+        "description": "Allows agents to signal their active status to Trento, supporting health monitoring and availability tracking for infrastructure management.",
+        "operationId": "TrentoWeb.V1.HostController.heartbeat",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host agent sending the heartbeat signal. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Heartbeat signal successfully updated for the host agent, supporting health monitoring and availability tracking."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Signal that an agent is alive.",
+        "tags": [
+          "Agent"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/abilities": {
+      "get": {
+        "callbacks": {},
+        "description": "Returns a comprehensive list of all abilities currently available in the system, allowing clients to understand supported actions and permissions for user management and access control.",
+        "operationId": "TrentoWeb.V1.AbilityController.index",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_AbilityCollection"
+                }
+              }
+            },
+            "description": "Comprehensive list of all abilities available for user management and access control in the system."
+          }
+        },
+        "summary": "Gets the list of abilities in the system.",
+        "tags": [
+          "User Management"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/suse_manager/test": {
+      "post": {
+        "callbacks": {},
+        "description": "Tests the connection to SUSE Manager using the currently saved credentials and configuration, supporting validation and troubleshooting of integration settings.",
+        "operationId": "TrentoWeb.V1.SettingsController.test_suse_manager_settings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The connection with SUSE Manager was successful."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "The connection with SUSE Manager failed."
+          }
+        },
+        "summary": "Tests connection with SUSE Manager.",
+        "tags": [
+          "Settings",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/software_updates": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves all available relevant patches and upgradable packages for a specified host, supporting automated software management and system maintenance.",
+        "operationId": "TrentoWeb.V1.SUSEManagerController.software_updates",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host for which software updates are being requested. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_AvailableSoftwareUpdatesResponse"
+                }
+              }
+            },
+            "description": "A comprehensive list of available software updates for the specified host, including all relevant patches and upgradable packages."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Gets available software updates for a given host.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/profile/totp_enrollment": {
+      "delete": {
+        "callbacks": {},
+        "description": "Resets the Time-based One-Time Password (TOTP) configuration for the currently authenticated user, allowing them to re-enroll in two-factor authentication if needed.",
+        "operationId": "TrentoWeb.V1.ProfileController.reset_totp",
+        "parameters": [],
+        "responses": {
+          "204": {
+            "description": "User TOTP enrollment reset."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          }
+        },
+        "summary": "Reset the TOTP configuration for the user.",
+        "tags": [
+          "Profile"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "description": "Returns TOTP enrollment data, including a QR code and related information, to help the user set up two-factor authentication for their account.",
+        "operationId": "TrentoWeb.V1.ProfileController.get_totp_enrollment_data",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserTOTPEnrollmentPayload"
+                }
+              }
+            },
+            "description": "TOTP enrollment data including QR code and related information for two-factor authentication setup."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Get TOTP enrollment data.",
+        "tags": [
+          "Profile"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "Confirms the TOTP enrollment process by validating the code generated by the authenticator app, enabling two-factor authentication for the user account.",
+        "operationId": "TrentoWeb.V1.ProfileController.confirm_totp_enrollment",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_UserTOTPEnrollmentConfirmRequest"
+              }
+            }
+          },
+          "description": "Request containing TOTP enrollment confirmation code for enabling two-factor authentication.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserTOTPEnrollmentConfirmPayload"
+                }
+              }
+            },
+            "description": "TOTP enrollment process completed successfully, enabling two-factor authentication for the user account."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Confirm TOTP enrollment procedure.",
+        "tags": [
+          "Profile"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/activity_log": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a paginated and filterable list of Activity Log entries, allowing clients to monitor system events, user actions, and platform changes for auditing and troubleshooting purposes.",
+        "operationId": "TrentoWeb.V1.ActivityLogController.get_activity_log",
+        "parameters": [
+          {
+            "description": "Specifies how many Activity Log entries to return starting from the beginning of the result set, supporting pagination for large datasets.",
+            "in": "query",
+            "name": "first",
+            "required": false,
+            "schema": {
+              "example": 10,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Specifies how many Activity Log entries to return starting from the end of the result set, useful for retrieving the most recent events.",
+            "in": "query",
+            "name": "last",
+            "required": false,
+            "schema": {
+              "example": 10,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "A cursor value used to paginate results after a specific entry, enabling efficient navigation through large logs.",
+            "in": "query",
+            "name": "after",
+            "required": false,
+            "schema": {
+              "example": "cursor_after_example",
+              "type": "string"
+            }
+          },
+          {
+            "description": "A cursor value used to paginate results before a specific entry, allowing backward navigation in the log entries.",
+            "in": "query",
+            "name": "before",
+            "required": false,
+            "schema": {
+              "example": "cursor_before_example",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filters Activity Log entries to include only those occurring on or after the specified start date, supporting time-based queries.",
+            "in": "query",
+            "name": "from_date",
+            "required": false,
+            "schema": {
+              "example": "2024-01-01T00:00:00Z",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filters Activity Log entries to include only those occurring on or before the specified end date, useful for defining a time range.",
+            "in": "query",
+            "name": "to_date",
+            "required": false,
+            "schema": {
+              "example": "2024-01-31T23:59:59Z",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filters Activity Log entries by one or more actors, allowing users to view actions performed by specific individuals or system accounts.",
+            "example": [
+              "john.doe@example.com",
+              "admin@example.com"
+            ],
+            "in": "query",
+            "name": "actor",
+            "required": false,
+            "schema": {
+              "example": [
+                "john.doe@example.com",
+                "admin@example.com"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Allows searching Activity Log entries using a keyword or phrase, helping users quickly locate relevant events or actions.",
+            "example": "user login",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "example": "user login",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filters Activity Log entries by one or more event types, enabling users to focus on specific categories of system activity.",
+            "example": [
+              "host_registered",
+              "user_login"
+            ],
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "example": [
+                "host_registered",
+                "user_login"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Filters Activity Log entries by severity level, allowing users to prioritize or review events based on their importance or impact.",
+            "in": "query",
+            "name": "severity",
+            "required": false,
+            "schema": {
+              "default": [
+                "debug",
+                "info",
+                "warning",
+                "critical"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_ActivityLog"
+                }
+              }
+            },
+            "description": "Comprehensive list of activity log entries retrieved for monitoring system events, user actions, and platform changes."
+          }
+        },
+        "summary": "Fetches the Activity Log entries.",
+        "tags": [
+          "Platform",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/clusters/{cluster_id}/checks/request_execution": {
+      "post": {
+        "callbacks": {},
+        "description": "Initiates the execution of the most recently selected Checks for a specified cluster on the target infrastructure, enabling automated validation and compliance assessment.",
+        "operationId": "TrentoWeb.V1.ClusterController.request_checks_execution",
+        "parameters": [
+          {
+            "description": "Unique identifier of the cluster for which the Checks execution is being requested. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "cluster_id",
+            "required": true,
+            "schema": {
+              "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Checks execution request for the specified cluster has been accepted and scheduled for processing."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Request Checks Execution for a Cluster.",
+        "tags": [
+          "Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/collect": {
+      "post": {
+        "callbacks": {},
+        "description": "Allows agents to submit collected data from the target infrastructure for processing and analysis, supporting automated discovery and system inventory updates.",
+        "operationId": "TrentoWeb.V1.DiscoveryController.collect",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_DiscoveryEvent"
+              }
+            }
+          },
+          "description": "Request containing discovery event data collected from the target infrastructure for processing and analysis.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Discovery event accepted for processing and infrastructure data analysis, supporting automated system inventory updates."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Collect data from the target infrastructure.",
+        "tags": [
+          "Agent",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/sap_systems/{id}/hosts/{host_id}/instances/{instance_number}/operations/{operation}": {
+      "post": {
+        "callbacks": {},
+        "description": "Submits a request to perform a specific operation on a SAP application instance, such as restart or configuration change, supporting automated infrastructure management.",
+        "operationId": "TrentoWeb.V1.SapSystemController.request_instance_operation",
+        "parameters": [
+          {
+            "description": "Unique identifier of the SAP system associated with the application instance. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Unique identifier of the host associated with the application instance. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The instance number of the SAP application instance, used to uniquely identify the specific instance within the host.",
+            "in": "path",
+            "name": "instance_number",
+            "required": true,
+            "schema": {
+              "example": "10",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies the type of operation to be performed on the SAP application instance, such as restart or configuration change.",
+            "in": "path",
+            "name": "operation",
+            "required": true,
+            "schema": {
+              "example": "restart",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_SapInstanceOperationParams"
+              }
+            }
+          },
+          "description": "Request containing parameters for the specified SAP application instance operation, such as restart or configuration change.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_OperationAccepted"
+                }
+              }
+            },
+            "description": "A detailed response indicating that the requested operation has been accepted for processing, including confirmation and tracking information."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Request operation for a SAP instance.",
+        "tags": [
+          "Operations"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/databases/{id}/tags": {
+      "post": {
+        "callbacks": {},
+        "description": "Adds a new tag to the specified database, supporting resource categorization and management for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.add_tag_to_database",
+        "parameters": [
+          {
+            "description": "Unique identifier of the database to which the tag will be added. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "value": {
+                    "example": "production",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Request containing tag value to be added to the specified database for resource categorization and management.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tag has been successfully added to the specified database, supporting resource categorization and management."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Add tag to database.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/databases": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a comprehensive list of all HANA Databases discovered on the target infrastructure, supporting monitoring and management tasks for administrators.",
+        "operationId": "TrentoWeb.V1.DatabaseController.list_databases",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_DatabasesCollection"
+                }
+              }
+            },
+            "description": "Comprehensive list of all HANA Databases discovered on the target infrastructure for monitoring and management."
+          }
+        },
+        "summary": "List HANA Databases.",
+        "tags": [
+          "Target Infrastructure"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/databases/{id}/tags/{value}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes a tag from the specified database, supporting resource management and cleanup for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.remove_tag_from_database",
+        "parameters": [
+          {
+            "description": "Unique identifier of the database from which the tag will be removed. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d1a2b3c4-d5e6-7890-abcd-ef1234567890",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The value of the tag to be removed from the database.",
+            "in": "path",
+            "name": "value",
+            "required": true,
+            "schema": {
+              "example": "production",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The tag has been removed from the database."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Remove tag from database.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/tags": {
+      "post": {
+        "callbacks": {},
+        "description": "Adds a new tag to the specified host, supporting resource categorization and management for infrastructure operations.",
+        "operationId": "TrentoWeb.V1.TagsController.add_tag_to_host",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host to which the tag will be added. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "value": {
+                    "example": "production",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "Request containing tag value to be added to the specified host for resource categorization and management.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {},
+                  "properties": {},
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tag has been successfully added to the specified host, supporting resource categorization and management."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a bad request, including information about the client-side issue encountered."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Add tag to host.",
+        "tags": [
+          "Tags"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/hosts/{id}/checks/request_execution": {
+      "post": {
+        "callbacks": {},
+        "description": "Initiates the execution of the most recently selected Checks for a specified host on the target infrastructure, enabling automated validation and compliance assessment.",
+        "operationId": "TrentoWeb.V1.HostController.request_checks_execution",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host for which the Checks execution is being requested. This value must be a valid UUID string.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Checks execution request for the specified host has been accepted and scheduled for processing."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Request Checks Execution for a Host.",
+        "tags": [
+          "Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/sap_systems": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a comprehensive list of all SAP Systems discovered on the target infrastructure, supporting monitoring and management tasks for administrators.",
+        "operationId": "TrentoWeb.V1.SapSystemController.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_SAPSystemsCollection"
+                }
+              }
+            },
+            "description": "Comprehensive list of all SAP Systems discovered on the target infrastructure for monitoring and management."
+          }
+        },
+        "summary": "List SAP Systems.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/software_updates/packages": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves all relevant patches that are covered by package upgrades in SUSE Manager for a specified host, supporting compliance and system maintenance.",
+        "operationId": "TrentoWeb.V1.SUSEManagerController.patches_for_packages",
+        "parameters": [
+          {
+            "description": "Unique identifier of the host for which patch information is being requested. This value must be a valid UUID string.",
+            "in": "query",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "example": "d59523fc-0497-4b1e-9fdd-14aa7cda77f1",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_PatchesForPackagesResponse"
+                }
+              }
+            },
+            "description": "A detailed list of all relevant patches covered by package upgrades in SUSE Manager for the specified host."
+          }
+        },
+        "summary": "Gets patches covered by package upgrades in SUSE Manager.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/alerting": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves the current configuration for alerting in Trento, including notification settings and integration details, supporting operational monitoring and incident response.",
+        "operationId": "TrentoWeb.V1.SettingsController.get_alerting_settings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_AlertingSettings"
+                }
+              }
+            },
+            "description": "A comprehensive set of alerting settings and configuration details for operational monitoring and incident response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Unauthorized"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that access to the requested operation is denied due to missing or invalid authentication credentials."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          }
+        },
+        "summary": "Get alerting settings.",
+        "tags": [
+          "Settings",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "description": "Updates the persisted alerting settings in Trento, allowing users to modify notification preferences and integration options for incident management.",
+        "operationId": "TrentoWeb.V1.SettingsController.update_alerting_settings",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_UpdateAlertingSettings"
+              }
+            }
+          },
+          "description": "Request body containing updated alerting settings and configuration for incident management and notification preferences.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_AlertingSettings"
+                }
+              }
+            },
+            "description": "Alerting settings have been successfully updated and modified, including configuration for incident management and notification preferences."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Unauthorized"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that access to the requested operation is denied due to missing or invalid authentication credentials."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Conflict"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a resource conflict, including information about the nature of the conflict encountered."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Update alerting settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "Creates new alerting settings in Trento, allowing users to configure notification preferences and integration options for incident management.",
+        "operationId": "TrentoWeb.V1.SettingsController.create_alerting_settings",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_CreateAlertingSettings"
+              }
+            }
+          },
+          "description": "Request body containing new alerting settings and configuration for incident management and notification preferences.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_AlertingSettings"
+                }
+              }
+            },
+            "description": "Alerting settings have been successfully created and modified, including configuration for incident management and notification preferences."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Unauthorized"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that access to the requested operation is denied due to missing or invalid authentication credentials."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Conflict"
+                }
+              }
+            },
+            "description": "A detailed error response indicating a resource conflict, including information about the nature of the conflict encountered."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Create alerting settings.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/{id}": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes a user account from the system, supporting user management and administrative cleanup.",
+        "operationId": "TrentoWeb.V1.UsersController.delete",
+        "parameters": [
+          {
+            "description": "Unique identifier of the user to be deleted. This value must be an integer.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "User account has been successfully deleted from the system, supporting administrative cleanup."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          }
+        },
+        "summary": "Delete a user.",
+        "tags": [
+          "User Management"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "get": {
+        "callbacks": {},
+        "description": "Returns detailed information about a specific user, identified by their unique ID, supporting user management and administrative review.",
+        "operationId": "TrentoWeb.V1.UsersController.show",
+        "parameters": [
+          {
+            "description": "Unique identifier of the user whose details are being requested. This value must be an integer.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserItem"
+                }
+              }
+            },
+            "description": "Detailed information about the specified user, including entity version for concurrency control.",
+            "headers": {
+              "etag": {
+                "description": "The entity version of the user, used for conditional HTTP requests and concurrency control.",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the requested resource could not be found, including information about the reason for the missing resource."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          }
+        },
+        "summary": "Show the details of a user.",
+        "tags": [
+          "User Management",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "patch": {
+        "callbacks": {},
+        "description": "Updates the details of an existing user. This is a conditional HTTP request; you must provide the entity version using the If-Match header to ensure safe updates and concurrency control.",
+        "operationId": "TrentoWeb.V1.UsersController.update",
+        "parameters": [
+          {
+            "description": "Unique identifier of the user to be updated. This value must be an integer.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The entity version of the user, provided in the If-Match header, to ensure safe and conditional updates.",
+            "in": "header",
+            "name": "if-match",
+            "required": false,
+            "schema": {
+              "example": 2,
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/2.5.0_v1_UserUpdateRequest"
+              }
+            }
+          },
+          "description": "Request containing updated user information and entity version for safe and conditional updates.",
+          "required": false
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UserItem"
+                }
+              }
+            },
+            "description": "User account updated successfully, returning the updated user details and entity version for concurrency control.",
+            "headers": {
+              "etag": {
+                "description": "The entity version of the user, used for conditional HTTP requests and concurrency control.",
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "A detailed error response indicating forbidden access, including information about insufficient permissions and why the operation could not be performed."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_PreconditionFailed"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that a precondition for the requested operation was not met, including information about resource conflicts or outdated data."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that the server cannot process the request due to semantic errors, such as invalid or missing values in the payload."
+          },
+          "428": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v1_PreconditionRequired"
+                }
+              }
+            },
+            "description": "A detailed error response indicating that a required precondition for the request is missing, including information about missing headers for conditional operations."
+          }
+        },
+        "summary": "Update an existing user.",
+        "tags": [
+          "User Management"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v2/clusters": {
+      "get": {
+        "callbacks": {},
+        "description": "Retrieves a comprehensive list of all Pacemaker Clusters discovered on the target infrastructure, supporting monitoring and management tasks for administrators.",
+        "operationId": "TrentoWeb.V2.ClusterController.list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/2.5.0_v2_PacemakerClustersCollection"
+                }
+              }
+            },
+            "description": "Comprehensive list of all Pacemaker Clusters discovered on the target infrastructure for monitoring and management."
+          }
+        },
+        "summary": "List Pacemaker Clusters.",
+        "tags": [
+          "Target Infrastructure",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/checks/catalog": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
+        "operationId": "WandaWeb.V1.CatalogController.catalog",
+        "parameters": [
+          {
+            "description": "Specify environment variables to filter or customize the returned catalog of checks.",
+            "example": {
+              "SOME_ENV": "value"
+            },
+            "explode": true,
+            "in": "query",
+            "name": "env",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/1.5.0_v1_ExecutionEnv"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "items": [
+                    {
+                      "description": "Verifies whether fencing is configured for all nodes in the cluster to ensure high availability.",
+                      "expectations": [
+                        {
+                          "expression": "fencing_configured == true",
+                          "failure_message": "Fencing is not configured for all nodes.",
+                          "name": "fencing_enabled",
+                          "type": "expect"
+                        }
+                      ],
+                      "facts": [
+                        {
+                          "argument": "",
+                          "gatherer": "cluster_node_gatherer",
+                          "name": "node_count"
+                        }
+                      ],
+                      "group": "SLES-HA",
+                      "id": "SLES-HA-1",
+                      "metadata": {
+                        "category": "ha",
+                        "impact": "critical"
+                      },
+                      "name": "Cluster node fencing configured",
+                      "premium": false,
+                      "remediation": "Configure fencing for all cluster nodes to ensure high availability.",
+                      "severity": "critical",
+                      "values": [
+                        {
+                          "conditions": [
+                            {
+                              "expression": "node_count > 1",
+                              "value": true
+                            }
+                          ],
+                          "default": false,
+                          "name": "fencing_configured"
+                        }
+                      ],
+                      "when": "node_count > 0"
+                    }
+                  ]
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_CatalogResponse"
+                }
+              }
+            },
+            "description": "A successful response containing the catalog of available checks."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "List checks catalog.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/checks/executions": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides a paginated list of executions performed in the system, supporting monitoring and analysis.",
+        "operationId": "WandaWeb.V1.ExecutionController.index",
+        "parameters": [
+          {
+            "description": "The unique identifier of the group to filter the executions list.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "query",
+            "name": "group_id",
+            "required": false,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specify the page number to retrieve paginated results for executions.",
+            "example": 3,
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Set the number of items to be returned per page in the paginated results.",
+            "example": 20,
+            "in": "query",
+            "name": "items_per_page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_ListExecutionsResponse"
+                }
+              }
+            },
+            "description": "A successful response containing a paginated list of executions."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "List executions.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/checks/executions/start": {
+      "post": {
+        "callbacks": {},
+        "description": "Initiates a new checks execution on the target infrastructure, enabling automated validation.",
+        "operationId": "WandaWeb.V1.ExecutionController.start",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/1.5.0_v1_StartExecutionRequest"
+              }
+            }
+          },
+          "description": "The context required to start a new execution, including necessary parameters.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_AcceptedExecutionResponse"
+                }
+              }
+            },
+            "description": "A successful response indicating the execution was accepted and started."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "This response indicates that the request was malformed or contained invalid parameters, and could not be processed."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Start a Checks Execution.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/checks/executions/{id}": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides detailed information about a specific execution identified by its ID.",
+        "operationId": "WandaWeb.V1.ExecutionController.show",
+        "parameters": [
+          {
+            "description": "The unique identifier of the execution to retrieve details for.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_ExecutionResponse"
+                }
+              }
+            },
+            "description": "A successful response containing details of the requested execution."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "This response indicates that the requested resource could not be found in the system."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Get an execution by ID.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/checks/groups/{id}/executions/last": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides details about the most recent execution for a specified group.",
+        "operationId": "WandaWeb.V1.ExecutionController.last",
+        "parameters": [
+          {
+            "description": "The unique identifier of the group for which the last execution is requested.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_ExecutionResponse"
+                }
+              }
+            },
+            "description": "A successful response containing details of the last execution for the specified group."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "This response indicates that the requested resource could not be found in the system."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Get the last execution of a group.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/groups/{group_id}/checks": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides a list of selectable checks for a specified group and environment, enabling targeted execution.",
+        "operationId": "WandaWeb.V1.CatalogController.selectable_checks",
+        "parameters": [
+          {
+            "description": "The unique identifier of the group for which selectable checks are to be listed.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specify environment variables to filter or customize the selectable checks returned.",
+            "explode": true,
+            "in": "query",
+            "name": "env",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/1.5.0_v1_ExecutionEnv"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_SelectableChecksResponse"
+                }
+              }
+            },
+            "description": "A successful response containing the selectable checks for the specified group and environment."
+          }
+        },
+        "summary": "List selectable checks for a given execution group and environment.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/groups/{group_id}/checks/{check_id}/customization": {
+      "delete": {
+        "callbacks": {},
+        "description": "Removes all previously applied customizations for a check in a specific group, restoring default values.",
+        "operationId": "WandaWeb.V1.ChecksCustomizationsController.reset_customization",
+        "parameters": [
+          {
+            "description": "The unique identifier of the check for which the customization is being reset.",
+            "example": "ABC123",
+            "in": "path",
+            "name": "check_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The unique identifier of the group for which the check's customization is being reset.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "A successful response indicating the customization was reset and defaults restored."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "This response indicates that the requested resource could not be found in the system."
+          }
+        },
+        "summary": "Reset the customizations applied for a specific check.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      },
+      "post": {
+        "callbacks": {},
+        "description": "Allows users to apply custom values to a specific check for a selected group, enabling tailored validation.",
+        "operationId": "WandaWeb.V1.ChecksCustomizationsController.apply_custom_values",
+        "parameters": [
+          {
+            "description": "The unique identifier of the check to which custom values are being applied.",
+            "example": "ABC123",
+            "in": "path",
+            "name": "check_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The unique identifier of the group for which the custom value is being set.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/1.5.0_v1_CustomizationRequest"
+              }
+            }
+          },
+          "description": "The custom values to be applied to the specified check.",
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_CustomizationResponse"
+                }
+              }
+            },
+            "description": "A successful response containing the applied customizations for the specified check and group."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_BadRequest"
+                }
+              }
+            },
+            "description": "This response indicates that the request was malformed or contained invalid parameters, and could not be processed."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_Forbidden"
+                }
+              }
+            },
+            "description": "This response indicates that access to the requested resource or operation is forbidden due to insufficient permissions."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "This response indicates that the requested resource could not be found in the system."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Apply custom values for a specific check.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/operations/executions": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides a paginated list of operations performed in the system, allowing for easy tracking and management.",
+        "operationId": "WandaWeb.V1.OperationController.index",
+        "parameters": [
+          {
+            "description": "The unique identifier of the group to filter the operations list.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "query",
+            "name": "group_id",
+            "required": false,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specify the page number to retrieve paginated results for operations.",
+            "example": 3,
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Set the number of items to be returned per page in the paginated results.",
+            "example": 20,
+            "in": "query",
+            "name": "items_per_page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter the operations by their status, using one of the allowed values.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "running",
+                "completed",
+                "aborted"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_ListOperationsResponse"
+                }
+              }
+            },
+            "description": "A successful response containing a paginated list of operations."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "List operations.",
+        "tags": [
+          "Wanda Checks",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v1/operations/executions/{id}": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides detailed information about a specific operation identified by its UUID.",
+        "operationId": "WandaWeb.V1.OperationController.show",
+        "parameters": [
+          {
+            "description": "The unique identifier (UUID) of the operation to retrieve details for.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_OperationResponse"
+                }
+              }
+            },
+            "description": "A successful response containing details of the requested operation."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_NotFound"
+                }
+              }
+            },
+            "description": "This response indicates that the requested resource could not be found in the system."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v1_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Get an operation by ID.",
+        "tags": [
+          "Wanda Checks",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v2/checks/catalog": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
+        "operationId": "WandaWeb.V2.CatalogController.catalog",
+        "parameters": [
+          {
+            "description": "Specify environment variables to filter or customize the returned catalog of checks.",
+            "explode": true,
+            "in": "query",
+            "name": "env",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/1.5.0_v2_ExecutionEnv"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_CatalogResponse"
+                }
+              }
+            },
+            "description": "A successful response containing the catalog of available checks."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "List checks catalog.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v2/checks/executions": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides a paginated list of executions performed in the system, supporting monitoring and analysis.",
+        "operationId": "WandaWeb.V2.ExecutionController.index",
+        "parameters": [
+          {
+            "description": "The unique identifier of the group to filter the executions list.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "query",
+            "name": "group_id",
+            "required": false,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specify the page number to retrieve paginated results for executions.",
+            "example": 3,
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Set the number of items to be returned per page in the paginated results.",
+            "example": 20,
+            "in": "query",
+            "name": "items_per_page",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_ListExecutionsResponse"
+                }
+              }
+            },
+            "description": "A successful response containing a paginated list of executions."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "List executions.",
+        "tags": [
+          "Wanda Checks",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v2/checks/executions/start": {
+      "post": {
+        "callbacks": {},
+        "description": "Initiates a new checks execution on the target infrastructure, enabling automated validation.",
+        "operationId": "WandaWeb.V2.ExecutionController.start",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/1.5.0_v2_StartExecutionRequest"
+              }
+            }
+          },
+          "description": "The context required to start a new execution, including necessary parameters.",
+          "required": false
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_AcceptedExecutionResponse"
+                }
+              }
+            },
+            "description": "A successful response indicating the execution was accepted and started."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_BadRequest"
+                }
+              }
+            },
+            "description": "This response indicates that the request was malformed or contained invalid parameters, and could not be processed."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Start a Checks Execution.",
+        "tags": [
+          "Wanda Checks"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v2/checks/executions/{id}": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides detailed information about a specific execution identified by its ID.",
+        "operationId": "WandaWeb.V2.ExecutionController.show",
+        "parameters": [
+          {
+            "description": "The unique identifier of the execution to retrieve details for.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_ExecutionResponse"
+                }
+              }
+            },
+            "description": "A successful response containing details of the requested execution."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_NotFound"
+                }
+              }
+            },
+            "description": "This response indicates that the requested resource could not be found in the system."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Get an execution by ID.",
+        "tags": [
+          "Wanda Checks",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v2/checks/groups/{id}/executions/last": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides details about the most recent execution for a specified group.",
+        "operationId": "WandaWeb.V2.ExecutionController.last",
+        "parameters": [
+          {
+            "description": "The unique identifier of the group for which the last execution is requested.",
+            "example": "c1a2b3c4-d5e6-7890-abcd-ef1234567890",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_ExecutionResponse"
+                }
+              }
+            },
+            "description": "A successful response containing details of the last execution for the specified group."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_NotFound"
+                }
+              }
+            },
+            "description": "This response indicates that the requested resource could not be found in the system."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v2_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "Get the last execution of a group.",
+        "tags": [
+          "Wanda Checks",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    },
+    "/api/v3/checks/catalog": {
+      "get": {
+        "callbacks": {},
+        "description": "Provides the catalog of checks that can be executed in the system for improved reliability and compliance.",
+        "operationId": "WandaWeb.V3.CatalogController.catalog",
+        "parameters": [
+          {
+            "description": "Specify environment variables to filter or customize the returned catalog of checks.",
+            "explode": true,
+            "in": "query",
+            "name": "env",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/1.5.0_v3_ExecutionEnv"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v3_CatalogResponse"
+                }
+              }
+            },
+            "description": "A successful response containing the catalog of available checks."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/1.5.0_v3_UnprocessableEntity"
+                }
+              }
+            },
+            "description": "This response indicates that the request could not be processed due to semantic errors or invalid data."
+          }
+        },
+        "summary": "List checks catalog.",
+        "tags": [
+          "Wanda Checks",
+          "MCP"
+        ],
+        "security": [
+          {
+            "authorization": []
+          }
+        ]
+      }
+    }
+  },
   "components": {
     "responses": {},
     "schemas": {
-      "CheckResult": {
+      "2.5.0_Health": {
         "additionalProperties": false,
-        "description": "The result of a check",
+        "description": "Represents the status response for a platform health check, including the state of critical system components such as the database.",
+        "example": {
+          "database": "pass"
+        },
         "properties": {
-          "agents_check_results": {
+          "database": {
+            "description": "Indicates the current status of the database connection, showing whether the platform can access its data store successfully.",
+            "enum": [
+              "pass",
+              "fail"
+            ],
+            "example": "pass",
+            "type": "string"
+          }
+        },
+        "title": "Health",
+        "type": "object"
+      },
+      "2.5.0_PublicKeys": {
+        "description": "A list of uploaded public keys used for secure authentication and access management.",
+        "example": [
+          {
+            "content": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7...",
+            "name": "my-key"
+          }
+        ],
+        "items": {
+          "description": "Details about an uploaded public key, including its name and content for authentication purposes.",
+          "example": {
+            "content": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7...",
+            "name": "my-key"
+          },
+          "properties": {
+            "content": {
+              "description": "The actual content of the public key, used for secure authentication and access.",
+              "example": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7...",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name assigned to the public key, which helps identify it for authentication.",
+              "example": "my-key",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": "PublicKeys",
+        "type": "array"
+      },
+      "2.5.0_Ready": {
+        "additionalProperties": false,
+        "description": "Represents the readiness status of the Trento Web platform, indicating whether the system is fully operational and available for use.",
+        "example": {
+          "ready": true
+        },
+        "properties": {
+          "ready": {
+            "description": "Indicates if the Trento Web platform is fully operational and ready to serve requests, supporting system health monitoring.",
+            "type": "boolean"
+          }
+        },
+        "title": "Ready",
+        "type": "object"
+      },
+      "2.5.0_Unauthorized": {
+        "additionalProperties": false,
+        "description": "Error response returned when access to the requested operation is denied due to missing or invalid authentication credentials.",
+        "example": {
+          "errors": [
+            {
+              "detail": "The requested operation could not be authorized.",
+              "title": "Unauthorized"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "description": "A list of error objects describing why access to the requested operation was denied, such as missing or invalid authentication credentials.",
+            "example": [
+              {
+                "detail": "The requested operation could not be authorized.",
+                "title": "Unauthorized"
+              }
+            ],
+            "items": {
+              "description": "Details about a specific error encountered when access is denied, including a human-readable message and error title.",
+              "properties": {
+                "detail": {
+                  "description": "A message describing the reason for the unauthorized access, such as missing or invalid authentication credentials.",
+                  "example": "The requested operation could not be authorized.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short title summarizing the error encountered when access is denied due to authorization failure.",
+                  "example": "Unauthorized",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "Unauthorized",
+        "type": "object"
+      },
+      "2.5.0_UnprocessableEntity": {
+        "additionalProperties": false,
+        "description": "Error response returned when the server cannot process the request due to semantic errors, such as invalid or missing values in the payload.",
+        "example": {
+          "errors": [
+            {
+              "detail": "null value where string expected",
+              "title": "Invalid value"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "description": "A list of error objects describing why the request could not be processed, such as semantic errors or invalid values in the payload.",
+            "example": [
+              {
+                "detail": "null value where string expected",
+                "title": "Invalid value"
+              }
+            ],
+            "items": {
+              "description": "Details about a specific error encountered when the request is unprocessable, including a human-readable message and error title.",
+              "properties": {
+                "detail": {
+                  "description": "A message describing the reason for the unprocessable entity error, such as invalid or missing values in the payload.",
+                  "example": "null value where string expected",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short title summarizing the error encountered when the request cannot be processed due to semantic issues.",
+                  "example": "Invalid value",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "detail"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "errors"
+        ],
+        "title": "UnprocessableEntity",
+        "type": "object"
+      },
+      "2.5.0_v1_ApiKeySettingsUpdateRequest": {
+        "additionalProperties": false,
+        "description": "Request body for api key settings update.",
+        "example": {
+          "expire_at": "2024-12-31T23:59:59Z"
+        },
+        "properties": {
+          "expire_at": {
+            "description": "The date and time when the API key should expire, supporting security and access control.",
+            "example": "2024-12-31T23:59:59Z",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "expire_at"
+        ],
+        "title": "ApiKeySettingsUpdateRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_PreconditionFailed": {
+        "additionalProperties": false,
+        "description": "Error response returned when a precondition for the requested operation is not met, such as a mid-air collision or outdated resource.",
+        "example": {
+          "errors": [
+            {
+              "detail": "Mid-air collision detected, please refresh the resource you are trying to update.",
+              "title": "Precondition Failed"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "description": "A list of error objects describing why the precondition for the requested operation was not met, such as resource conflicts or outdated data.",
+            "example": [
+              {
+                "detail": "Mid-air collision detected, please refresh the resource you are trying to update.",
+                "title": "Precondition Failed"
+              }
+            ],
+            "items": {
+              "description": "Details about a specific error encountered when a precondition fails, including a human-readable message and error title.",
+              "properties": {
+                "detail": {
+                  "description": "A message describing the reason for the precondition failure, such as a mid-air collision or outdated resource.",
+                  "example": "Mid-air collision detected, please refresh the resource you are trying to update.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short title summarizing the error encountered when the precondition is not met.",
+                  "example": "Precondition Failed",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "PreconditionFailed",
+        "type": "object"
+      },
+      "2.5.0_v1_Ability": {
+        "additionalProperties": false,
+        "description": "Represents a specific capability or permission that can be assigned to a user or resource in the system.",
+        "example": {
+          "id": 1,
+          "label": "Can do anything",
+          "name": "all",
+          "resource": "all"
+        },
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the ability, used to reference and manage permissions.",
+            "nullable": false,
+            "type": "integer"
+          },
+          "label": {
+            "description": "Provides additional details about the ability, clarifying its purpose and scope within the system.",
+            "nullable": false,
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the ability, which describes the permission or action granted.",
+            "nullable": false,
+            "type": "string"
+          },
+          "resource": {
+            "description": "Indicates the resource to which this ability is associated, enabling fine-grained access control.",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "resource"
+        ],
+        "title": "Ability",
+        "type": "object"
+      },
+      "2.5.0_v1_PrometheusExporterStatus": {
+        "additionalProperties": {
+          "description": "The health status of a Prometheus exporter, which can be 'passing', 'critical', or 'unknown', used to indicate monitoring and alerting conditions.",
+          "enum": [
+            "critical",
+            "passing",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        "description": "Represents the status information for Prometheus exporters, indicating their health and operational state for monitoring purposes.",
+        "example": {
+          "Node exporter": "critical"
+        },
+        "title": "PrometheusExporterStatus",
+        "type": "object"
+      },
+      "2.5.0_v1_HostCpuChart": {
+        "additionalProperties": false,
+        "description": "Represents a time series chart that provides detailed information about the CPU usage of a host over a period of time.",
+        "example": {
+          "busy_iowait": {
+            "label": "Busy (I/O wait)",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 5.2
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 6.1
+              }
+            ]
+          },
+          "busy_irqs": {
+            "label": "Busy (IRQs)",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 1
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 1.2
+              }
+            ]
+          },
+          "busy_other": {
+            "label": "Busy (Other)",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 2.5
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 2.8
+              }
+            ]
+          },
+          "busy_system": {
+            "label": "Busy (System)",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 15.3
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 16.1
+              }
+            ]
+          },
+          "busy_user": {
+            "label": "Busy (User)",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 25.4
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 28.2
+              }
+            ]
+          },
+          "idle": {
+            "label": "Idle",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 50.6
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 45.6
+              }
+            ]
+          }
+        },
+        "properties": {
+          "busy_iowait": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "busy_irqs": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "busy_other": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "busy_system": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "busy_user": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "idle": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          }
+        },
+        "title": "HostCpuChart",
+        "type": "object"
+      },
+      "2.5.0_v1_PacemakerCluster": {
+        "additionalProperties": false,
+        "description": "Represents a Pacemaker Cluster discovered on the target infrastructure, including its configuration, health, and associated resources.",
+        "example": {
+          "additional_sids": [
+            "ASCS"
+          ],
+          "cib_last_written": "2024-01-15T10:30:00Z",
+          "details": {
+            "nodes": [],
+            "secondary_sync_state": "SOK",
+            "system_replication_mode": "sync",
+            "system_replication_operation_mode": "logreplay"
+          },
+          "health": "passing",
+          "hosts_number": 2,
+          "id": "123e4567-e89b-12d3-a456-426614174000",
+          "inserted_at": "2024-01-15T09:00:00Z",
+          "name": "hana_cluster",
+          "provider": "azure",
+          "resources_number": 10,
+          "selected_checks": [
+            "check_2"
+          ],
+          "sid": "PRD",
+          "tags": [
+            {
+              "resource_id": "123e4567-e89b-12d3-a456-426614174000",
+              "resource_type": "cluster",
+              "value": "production"
+            }
+          ],
+          "type": "hana_scale_up",
+          "updated_at": "2024-01-15T10:30:00Z"
+        },
+        "properties": {
+          "additional_sids": {
+            "description": "A list of additional SIDs discovered in the cluster, such as ASCS or ERS, supporting SAP landscape management.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cib_last_written": {
+            "description": "The date and time when the cluster's CIB was last written, supporting audit and change tracking.",
+            "nullable": true,
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/components/schemas/2.5.0_v1_PacemakerClusterDetails"
+          },
+          "health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "hosts_number": {
+            "description": "Shows the number of hosts that are part of the cluster, supporting infrastructure management.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "id": {
+            "description": "Unique identifier for the cluster, used for tracking and management.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name assigned to the cluster, used for identification and organization.",
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/2.5.0_v1_SupportedProviders"
+          },
+          "resources_number": {
+            "description": "Indicates the number of resources associated with the cluster, supporting capacity and infrastructure planning.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "selected_checks": {
+            "description": "A list containing the IDs of checks selected for execution on this cluster, supporting targeted monitoring and analysis.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sid": {
+            "description": "The system identifier (SID) for the cluster, used for SAP system management.",
+            "type": "string"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/2.5.0_v1_Tags"
+          },
+          "type": {
+            "description": "Specifies the detected type of the cluster, such as HANA scale-up or scale-out, for classification and management.",
+            "enum": [
+              "hana_scale_up",
+              "hana_scale_out",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "PacemakerCluster",
+        "type": "object"
+      },
+      "2.5.0_v1_HttpStd": {
+        "additionalProperties": false,
+        "description": "Represents the configuration for HTTP service discovery targets, including endpoints and associated labels for monitoring and management.",
+        "example": {
+          "labels": {
+            "labelname": "mylabel"
+          },
+          "targets": [
+            "myhost.de"
+          ]
+        },
+        "properties": {
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "A set of labels with string values, used for categorizing and identifying service discovery targets.",
+            "type": "object"
+          },
+          "targets": {
+            "description": "A list containing all target endpoints for HTTP service discovery, supporting network monitoring and management.",
+            "items": {
+              "anyOf": [
+                {
+                  "description": "Represents the format of an IPv6 address, supporting modern network identification and communication.",
+                  "example": "2001:db8::1",
+                  "format": "ipv6",
+                  "title": "IPv6",
+                  "type": "string"
+                },
+                {
+                  "description": "Represents the format of an IPv4 address, used for network identification and communication.",
+                  "example": "192.168.1.100",
+                  "format": "ipv4",
+                  "title": "IPv4",
+                  "type": "string"
+                },
+                {
+                  "description": "Represents the format of a hostname, supporting network identification and service discovery.",
+                  "format": "hostname",
+                  "type": "string"
+                }
+              ],
+              "description": "Represents a target endpoint for service discovery, which may be a hostname, IPv4, or IPv6 address, supporting connectivity and identification."
+            },
+            "type": "array"
+          }
+        },
+        "title": "HttpStd",
+        "type": "object"
+      },
+      "2.5.0_v1_ChartTimeSeries": {
+        "additionalProperties": false,
+        "description": "Represents a time series for a chart, containing a sequence of float values distributed over time for visualization and analysis.",
+        "example": {
+          "label": "CPU Usage",
+          "series": [
+            {
+              "timestamp": "2024-01-15T10:00:00Z",
+              "value": 75.5
+            },
+            {
+              "timestamp": "2024-01-15T10:01:00Z",
+              "value": 80.2
+            }
+          ]
+        },
+        "properties": {
+          "label": {
+            "description": "A descriptive label for the time series, used for identification in chart visualizations.",
+            "type": "string"
+          },
+          "series": {
+            "description": "A list of values representing the time series data points, each associated with a timestamp for trend analysis.",
+            "items": {
+              "description": "Represents a data point in the time series, consisting of a timestamp and a corresponding float value.",
+              "properties": {
+                "timestamp": {
+                  "description": "The ISO8601 formatted timestamp indicating when the data point was recorded in the time series.",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "value": {
+                  "description": "The float value associated with the timestamp, representing the measured metric at that point in time.",
+                  "example": 270396.203,
+                  "format": "float",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "ChartTimeSeries",
+        "type": "object"
+      },
+      "2.5.0_v1_UserTOTPEnrollmentPayload": {
+        "additionalProperties": false,
+        "description": "Trento User TOTP enrollment payload.",
+        "example": {
+          "secret": "JBSWY3DPEHPK3PXP",
+          "secret_qr_encoded": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAYAAAA+s9J6AAA..."
+        },
+        "properties": {
+          "secret": {
+            "description": "TOTP secret.",
+            "example": "JBSWY3DPEHPK3PXP",
+            "nullable": false,
+            "type": "string"
+          },
+          "secret_qr_encoded": {
+            "description": "TOTP secret qr encoded.",
+            "example": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAYAAAA+s9J6AAA...",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "required": [
+          "secret",
+          "secret_qr_encoded"
+        ],
+        "title": "UserTOTPEnrollmentPayload",
+        "type": "object"
+      },
+      "2.5.0_v1_Database": {
+        "additionalProperties": false,
+        "description": "Represents a discovered HANA Database on the target infrastructure, including its configuration, health, and associated instances.",
+        "example": {
+          "database_instances": [],
+          "health": "passing",
+          "id": "9c86eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "inserted_at": "2024-01-15T10:30:00Z",
+          "sid": "HA1",
+          "tags": [],
+          "updated_at": "2024-01-15T12:30:00Z"
+        },
+        "properties": {
+          "database_instances": {
+            "$ref": "#/components/schemas/2.5.0_v1_DatabaseInstances"
+          },
+          "health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "id": {
+            "description": "Unique identifier for the HANA database, used for tracking and management.",
+            "example": "9c86eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "example": "2024-01-15T10:30:00Z",
+            "format": "datetime",
+            "type": "string"
+          },
+          "sid": {
+            "description": "The system identifier (SID) for the HANA database, used for SAP system management.",
+            "example": "HA1",
+            "type": "string"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/2.5.0_v1_Tags"
+          },
+          "updated_at": {
+            "example": "2024-01-15T12:30:00Z",
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "Database",
+        "type": "object"
+      },
+      "2.5.0_v1_DiscoveryEvent": {
+        "additionalProperties": false,
+        "description": "Represents a discovery event generated by an agent, including its type, payload, and associated metadata for infrastructure monitoring.",
+        "example": {
+          "agent_id": "123e4567-e89b-12d3-a456-426614174000",
+          "discovery_type": "host_discovery",
+          "payload": {
+            "agent_version": "1.0.0",
+            "hostname": "suse-node1",
+            "ip_addresses": [
+              "10.1.1.2"
+            ]
+          }
+        },
+        "properties": {
+          "agent_id": {
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "format": "uuid",
+            "type": "string"
+          },
+          "discovery_type": {
+            "example": "host_discovery",
+            "type": "string"
+          },
+          "payload": {
+            "oneOf": [
+              {
+                "type": "object"
+              },
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ]
+          }
+        },
+        "required": [
+          "agent_id",
+          "discovery_type",
+          "payload"
+        ],
+        "title": "DiscoveryEvent",
+        "type": "object"
+      },
+      "2.5.0_v1_IPv4": {
+        "description": "Represents the format of an IPv4 address, used for network identification and communication.",
+        "example": "192.168.1.100",
+        "format": "ipv4",
+        "title": "IPv4",
+        "type": "string"
+      },
+      "2.5.0_v1_SaptuneNote": {
+        "additionalProperties": false,
+        "description": "Represents a saptune note, including its identifier and whether it is additionally enabled for system tuning and compliance.",
+        "example": {
+          "additionally_enabled": false,
+          "id": "1410736"
+        },
+        "properties": {
+          "additionally_enabled": {
+            "description": "Indicates whether the saptune note is additionally enabled, supporting compliance and configuration management.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Unique identifier for the saptune note, supporting tracking and management of system tuning recommendations.",
+            "type": "string"
+          }
+        },
+        "title": "SaptuneNote",
+        "type": "object"
+      },
+      "2.5.0_v1_Tags": {
+        "description": "A list of tags attached to a resource, supporting resource classification, filtering, and management across the infrastructure.",
+        "example": [
+          {
+            "id": 1,
+            "inserted_at": "2024-01-15T09:00:00Z",
+            "resource_id": "123e4567-e89b-12d3-a456-426614174000",
+            "resource_type": "host",
+            "updated_at": "2024-01-15T10:30:00Z",
+            "value": "production"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_Tag"
+        },
+        "title": "Tags",
+        "type": "array"
+      },
+      "2.5.0_v1_PacemakerClusterDetails": {
+        "description": "Provides details about the detected PacemakerCluster, including configuration, health, and operational status.",
+        "example": {
+          "fencing_type": "external/sbd",
+          "nodes": [
+            {
+              "hana_status": "Primary",
+              "name": "hana01",
+              "site": "NUREMBERG"
+            }
+          ],
+          "sbd_devices": [
+            {
+              "device": "/dev/disk/by-id/scsi-SLIO-ORG_disk_01",
+              "status": "healthy"
+            }
+          ],
+          "secondary_sync_state": "SOK",
+          "sr_health_state": "4",
+          "stopped_resources": [],
+          "system_replication_mode": "sync",
+          "system_replication_operation_mode": "logreplay"
+        },
+        "nullable": true,
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_HanaClusterDetails"
+          }
+        ],
+        "title": "PacemakerClusterDetails",
+        "type": "object"
+      },
+      "2.5.0_v1_ApplicationInstance": {
+        "additionalProperties": false,
+        "description": "Represents a discovered SAP application instance on the target infrastructure, including identification, features, ports, and health status for monitoring and management.",
+        "example": {
+          "absent_at": "2024-01-16T08:00:00Z",
+          "features": "MESSAGESERVER|ENQUE",
+          "health": "passing",
+          "host_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+          "http_port": 8000,
+          "https_port": 44300,
+          "inserted_at": "2024-01-15T10:30:00Z",
+          "instance_hostname": "sap-app-01",
+          "instance_number": "00",
+          "sap_system_id": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "sid": "HA1",
+          "start_priority": "1",
+          "updated_at": "2024-01-15T12:30:00Z"
+        },
+        "properties": {
+          "absent_at": {
+            "description": "Timestamp indicating when the application instance became absent from the infrastructure, supporting audit and monitoring.",
+            "example": "2024-01-16T08:00:00Z",
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          },
+          "features": {
+            "description": "A list of features enabled for this SAP application instance, supporting capability tracking.",
+            "example": "MESSAGESERVER|ENQUE",
+            "type": "string"
+          },
+          "health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "host_id": {
+            "description": "Unique identifier of the host where this application instance is running, supporting resource mapping.",
+            "example": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+            "format": "uuid",
+            "type": "string"
+          },
+          "http_port": {
+            "description": "The HTTP port number used by this SAP application instance, supporting connectivity and monitoring.",
+            "example": 8000,
+            "nullable": true,
+            "type": "integer"
+          },
+          "https_port": {
+            "description": "The HTTPS port number used by this SAP application instance, supporting secure connectivity.",
+            "example": 44300,
+            "nullable": true,
+            "type": "integer"
+          },
+          "inserted_at": {
+            "example": "2024-01-15T10:30:00Z",
+            "format": "datetime",
+            "type": "string"
+          },
+          "instance_hostname": {
+            "description": "The hostname of the server where this SAP application instance is running, supporting network management.",
+            "example": "sap-app-01",
+            "nullable": true,
+            "type": "string"
+          },
+          "instance_number": {
+            "description": "The instance number assigned to this SAP application instance, supporting unique identification.",
+            "example": "00",
+            "type": "string"
+          },
+          "sap_system_id": {
+            "description": "Unique identifier for the SAP system to which this application instance belongs, supporting resource tracking and management.",
+            "example": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "sid": {
+            "description": "The SAP system identifier (SID) for this application instance, supporting system identification.",
+            "example": "HA1",
+            "type": "string"
+          },
+          "start_priority": {
+            "description": "The start priority assigned to this SAP application instance, supporting startup sequencing and management.",
+            "example": "1",
+            "nullable": true,
+            "type": "string"
+          },
+          "updated_at": {
+            "example": "2024-01-15T12:30:00Z",
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "ApplicationInstance",
+        "type": "object"
+      },
+      "2.5.0_v1_SlesSubscription": {
+        "additionalProperties": false,
+        "description": "Represents a discovered SLES subscription on a host, including identification, version, architecture, status, and validity period for license management and compliance.",
+        "example": {
+          "arch": "x86_64",
+          "expires_at": "2025-12-31T23:59:59Z",
+          "host_id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+          "identifier": "SLES_SAP-15-SP3",
+          "starts_at": "2024-01-01T00:00:00Z",
+          "status": "Registered",
+          "subscription_status": "ACTIVE",
+          "type": "FULL",
+          "version": "15.3"
+        },
+        "properties": {
+          "arch": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "string"
+          },
+          "host_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "identifier": {
+            "type": "string"
+          },
+          "starts_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "subscription_status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "title": "SlesSubscription",
+        "type": "object"
+      },
+      "2.5.0_v1_SapInstanceOperationParams": {
+        "description": "Request parameters for SAP instance operations, supporting flexible control over instance lifecycle actions.",
+        "example": {
+          "timeout": 300
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_StartStopParams"
+          }
+        ],
+        "title": "SapInstanceOperationParams",
+        "type": "object"
+      },
+      "2.5.0_v1_HostsCollection": {
+        "description": "A list containing all discovered hosts on the target infrastructure, supporting monitoring and management.",
+        "example": [
+          {
+            "agent_version": "1.0.0",
+            "cluster_id": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "health": "passing",
+            "hostname": "suse-node1",
+            "id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+            "inserted_at": "2024-01-15T10:30:00Z",
+            "ip_addresses": [
+              "10.1.1.2",
+              "192.168.1.10"
+            ],
+            "selected_checks": [],
+            "tags": [],
+            "updated_at": "2024-01-15T12:30:00Z"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_Host"
+        },
+        "title": "HostsCollection",
+        "type": "array"
+      },
+      "2.5.0_v1_BadRequest": {
+        "additionalProperties": false,
+        "description": "Represents an error response for a bad request, providing details about the nature of the client-side issue.",
+        "example": {
+          "errors": [
+            {
+              "detail": "Invalid request payload.",
+              "title": "Bad Request"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
+              {
+                "detail": "Invalid request payload.",
+                "title": "Bad Request"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "description": "Provides a detailed explanation of the error encountered in the request, supporting troubleshooting and resolution.",
+                  "example": "Invalid request payload.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short summary of the error type, used for quick identification and error handling.",
+                  "example": "Bad Request",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "BadRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_SupportedProviders": {
+        "description": "Indicates the cloud provider detected for the resource, such as Azure, AWS, or GCP, supporting infrastructure identification.",
+        "enum": [
+          "azure",
+          "aws",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "vmware",
+          "unknown"
+        ],
+        "example": "azure",
+        "title": "SupportedProviders",
+        "type": "string"
+      },
+      "2.5.0_v1_UserCollection": {
+        "description": "A collection of users in the system.",
+        "example": [
+          {
+            "abilities": [],
+            "created_at": "2024-01-15T09:00:00Z",
+            "email": "john.doe@example.com",
+            "enabled": true,
+            "fullname": "John Doe",
+            "id": 1,
+            "password_change_requested_at": "2024-01-14T08:00:00Z",
+            "totp_enabled_at": "2024-01-15T10:00:00Z",
+            "updated_at": "2024-01-15T10:30:00Z",
+            "username": "john.doe"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_UserItem"
+        },
+        "title": "UserCollection",
+        "type": "array"
+      },
+      "2.5.0_v1_SaptuneSolutionApplyParams": {
+        "additionalProperties": false,
+        "description": "Represents the parameters for applying a Saptune solution to a host, supporting automated configuration and compliance.",
+        "example": {
+          "solution": "HANA"
+        },
+        "properties": {
+          "solution": {
+            "example": "HANA",
+            "type": "string"
+          }
+        },
+        "required": [
+          "solution"
+        ],
+        "title": "SaptuneSolutionApplyParams",
+        "type": "object"
+      },
+      "2.5.0_v1_Tag": {
+        "additionalProperties": false,
+        "description": "Represents a tag attached to a resource, including its identifier, type, value, and timestamps for resource classification and management.",
+        "example": {
+          "id": 1,
+          "inserted_at": "2024-01-15T09:00:00Z",
+          "resource_id": "123e4567-e89b-12d3-a456-426614174000",
+          "resource_type": "host",
+          "updated_at": "2024-01-15T10:30:00Z",
+          "value": "production"
+        },
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "inserted_at": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "resource_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "resource_type": {
+            "enum": [
+              "host",
+              "cluster",
+              "sap_system",
+              "database"
+            ],
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "title": "Tag",
+        "type": "object"
+      },
+      "2.5.0_v1_UserTOTPEnrollmentConfirmRequest": {
+        "additionalProperties": false,
+        "description": "Trento User totp enrollment confirmation payload.",
+        "example": {
+          "totp_code": "123456"
+        },
+        "properties": {
+          "totp_code": {
+            "description": "TOTP generated from enrollment secret.",
+            "example": "123456",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "required": [
+          "totp_code"
+        ],
+        "title": "UserTOTPEnrollmentConfirmRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_UpdateSuseManagerSettingsRequest": {
+        "additionalProperties": false,
+        "description": "Request body for updating SUMA settings.\nOnly provide fields to be updated.",
+        "example": {
+          "url": "https://suse-manager.example.com",
+          "username": "admin"
+        },
+        "minProperties": 1,
+        "properties": {
+          "ca_cert": {
+            "example": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV\n...\n-----END CERTIFICATE-----",
+            "nullable": true,
+            "type": "string"
+          },
+          "password": {
+            "example": "secretpassword",
+            "type": "string"
+          },
+          "url": {
+            "example": "https://suse-manager.example.com",
+            "type": "string"
+          },
+          "username": {
+            "example": "admin",
+            "type": "string"
+          }
+        },
+        "title": "UpdateSuseManagerSettingsRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_ActivityLogEntries": {
+        "description": "A collection of activity log entries that record significant events and actions within the platform for auditing and monitoring purposes.",
+        "example": [
+          {
+            "actor": "system",
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "metadata": {
+              "host_id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+              "hostname": "hana01"
+            },
+            "occurred_on": "2024-01-15T10:30:00Z",
+            "severity": "info",
+            "type": "host_registered"
+          }
+        ],
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "actor": {
+              "description": "Identifies the actor responsible for triggering the activity log entry, such as a system process or a specific user.",
+              "type": "string"
+            },
+            "id": {
+              "description": "A universally unique identifier (UUID v4) assigned to each activity log entry for precise tracking and reference.",
+              "format": "uuid",
+              "type": "string"
+            },
+            "metadata": {
+              "type": "object"
+            },
+            "occurred_on": {
+              "description": "Records the exact time when the activity log entry was created, providing chronological context for events.",
+              "type": "string"
+            },
+            "severity": {
+              "description": "Indicates the severity level of the activity log entry, such as informational, warning, error, or critical.",
+              "enum": [
+                "debug",
+                "info",
+                "warning",
+                "error",
+                "critical"
+              ],
+              "type": "string"
+            },
+            "type": {
+              "description": "Specifies the category or nature of the activity log entry, helping to classify the recorded event.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "type",
+            "actor",
+            "metadata",
+            "occurred_on"
+          ],
+          "title": "ActivityLogEntries",
+          "type": "object"
+        },
+        "title": "ActivityLogEntries",
+        "type": "array"
+      },
+      "2.5.0_v1_PatchesForPackagesResponse": {
+        "additionalProperties": false,
+        "description": "Represents the response returned from the patches for packages endpoint, detailing all relevant patches for upgraded packages.",
+        "example": {
+          "patches": [
+            {
+              "package_id": 1234,
+              "patches": [
+                {
+                  "advisory": "SUSE-SU-2024:0001-1",
+                  "advisory_type": "security_advisory",
+                  "issue_date": "2024-01-15",
+                  "last_modified_date": "2024-01-15",
+                  "synopsis": "Critical security update for OpenSSL"
+                }
+              ]
+            }
+          ]
+        },
+        "properties": {
+          "patches": {
+            "description": "A list of the relevant patches covered by the provided package upgrades.",
+            "example": [
+              {
+                "package_id": 1234,
+                "patches": [
+                  {
+                    "advisory": "SUSE-SU-2024:0001-1",
+                    "advisory_type": "security_advisory",
+                    "issue_date": "2024-01-15",
+                    "last_modified_date": "2024-01-15",
+                    "synopsis": "Critical security update for OpenSSL"
+                  }
+                ]
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_PatchesForPackage"
+            },
+            "type": "array"
+          }
+        },
+        "title": "PatchesForPackagesResponse",
+        "type": "object"
+      },
+      "2.5.0_v1_ClusterOperationParams": {
+        "description": "Represents the parameters for a cluster operation request, including maintenance changes for resources or nodes.",
+        "example": {
+          "maintenance": true,
+          "node_id": "node_1",
+          "resource_id": "resource_1"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_ClusterMaintenanceChangeParams"
+          }
+        ],
+        "title": "ClusterOperationParams",
+        "type": "object"
+      },
+      "2.5.0_v1_SuseManagerSettings": {
+        "additionalProperties": false,
+        "description": "Represents the settings for SUSE Manager, including connection details and certificate upload information for secure management.",
+        "example": {
+          "ca_uploaded_at": "2024-01-15T10:30:00Z",
+          "url": "https://suse-manager.example.com",
+          "username": "admin"
+        },
+        "properties": {
+          "ca_uploaded_at": {
+            "description": "The date and time when the SSL certificate was uploaded to SUSE Manager, supporting audit and security management.",
+            "example": "2024-01-15T10:30:00Z",
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL used to access SUSE Manager, supporting connectivity and management.",
+            "example": "https://suse-manager.example.com",
+            "type": "string"
+          },
+          "username": {
+            "description": "The username used for authentication with SUSE Manager, supporting secure access.",
+            "example": "admin",
+            "type": "string"
+          }
+        },
+        "title": "SuseManagerSettings",
+        "type": "object"
+      },
+      "2.5.0_v1_SapSystemOperationParams": {
+        "description": "Request parameters for SAP system operations, supporting actions such as starting or stopping system instances with configurable options.",
+        "example": {
+          "timeout": 300
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_StartStopParams"
+          }
+        ],
+        "title": "SapSystemOperationParams",
+        "type": "object"
+      },
+      "2.5.0_v1_SAPSystem": {
+        "additionalProperties": false,
+        "description": "Represents a discovered SAP system on the target infrastructure, including identification, database, health, and instance details for monitoring and management.",
+        "example": {
+          "application_instances": [],
+          "database_id": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "database_instances": [],
+          "database_sid": "HA1",
+          "db_host": "10.1.1.5",
+          "ensa_version": "ensa1",
+          "health": "passing",
+          "id": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "inserted_at": "2024-01-15T10:30:00Z",
+          "sid": "HA1",
+          "tags": [],
+          "tenant": "PRD",
+          "updated_at": "2024-01-15T12:30:00Z"
+        },
+        "properties": {
+          "application_instances": {
+            "description": "A list of the discovered Application Instances for current SAP Systems.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_ApplicationInstance"
+            },
+            "type": "array"
+          },
+          "database_id": {
+            "description": "Database ID.",
+            "example": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "database_instances": {
+            "$ref": "#/components/schemas/2.5.0_v1_DatabaseInstances"
+          },
+          "database_sid": {
+            "description": "Database SID.",
+            "example": "HA1",
+            "type": "string"
+          },
+          "db_host": {
+            "description": "The address of the database connected to this SAP system, supporting connectivity and monitoring.",
+            "example": "10.1.1.5",
+            "type": "string"
+          },
+          "ensa_version": {
+            "description": "ENSA version of the SAP system.",
+            "enum": [
+              "no_ensa",
+              "ensa1",
+              "ensa2"
+            ],
+            "example": "ensa1",
+            "type": "string"
+          },
+          "health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "id": {
+            "description": "Unique identifier for the SAP system, supporting resource tracking and management.",
+            "example": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "example": "2024-01-15T10:30:00Z",
+            "format": "datetime",
+            "type": "string"
+          },
+          "sid": {
+            "description": "The SAP system identifier (SID) for this system, supporting system identification.",
+            "example": "HA1",
+            "type": "string"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/2.5.0_v1_Tags"
+          },
+          "tenant": {
+            "description": "The tenant identifier for this SAP system, supporting multi-tenancy and resource management.",
+            "example": "PRD",
+            "type": "string"
+          },
+          "updated_at": {
+            "example": "2024-01-15T12:30:00Z",
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "SAPSystem",
+        "type": "object"
+      },
+      "2.5.0_v1_UserProfile": {
+        "additionalProperties": false,
+        "description": "Trento User profile.",
+        "example": {
+          "abilities": [],
+          "analytics_enabled": false,
+          "created_at": "2024-01-15T09:00:00Z",
+          "email": "john.doe@example.com",
+          "fullname": "John Doe",
+          "id": 1,
+          "idp_user": false,
+          "password_change_requested": false,
+          "totp_enabled": true,
+          "updated_at": "2024-01-15T12:00:00Z",
+          "username": "jdoe"
+        },
+        "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/2.5.0_v1_AbilityCollection"
+          },
+          "analytics_enabled": {
+            "description": "Whether user analytics collection is enabled.",
+            "example": false,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "created_at": {
+            "description": "Date of user creation.",
+            "example": "2024-01-15T09:00:00Z",
+            "format": "date-time",
+            "nullable": false,
+            "type": "string"
+          },
+          "email": {
+            "description": "The email address associated with the user, used for communication, authentication, and account management within the system.",
+            "example": "john.doe@example.com",
+            "format": "email",
+            "nullable": false,
+            "type": "string"
+          },
+          "fullname": {
+            "description": "User full name.",
+            "example": "John Doe",
+            "nullable": false,
+            "type": "string"
+          },
+          "id": {
+            "description": "User ID.",
+            "example": 1,
+            "nullable": false,
+            "type": "integer"
+          },
+          "idp_user": {
+            "description": "User coming from an external IDP.",
+            "example": false,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "password_change_requested": {
+            "description": "Password change is requested.",
+            "example": false,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "totp_enabled": {
+            "description": "TOTP is enabled.",
+            "example": true,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "updated_at": {
+            "description": "Date of user last update.",
+            "example": "2024-01-15T12:00:00Z",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "username": {
+            "description": "User username.",
+            "example": "jdoe",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "id",
+          "fullname",
+          "email",
+          "created_at",
+          "totp_enabled"
+        ],
+        "title": "UserProfile",
+        "type": "object"
+      },
+      "2.5.0_v1_AffectedPackages": {
+        "additionalProperties": false,
+        "description": "Represents the response returned from the get affected packages endpoint, listing all packages affected by advisories.",
+        "example": [
+          {
+            "arch_label": "x86_64",
+            "epoch": "0",
+            "name": "openssl",
+            "release": "1.2",
+            "version": "1.1.1"
+          }
+        ],
+        "items": {
+          "description": "Provides metadata for a package affected by an advisory, supporting tracking and management of vulnerabilities.",
+          "properties": {
+            "arch_label": {
+              "description": "Specifies the architecture of the affected package, such as x86_64 or arm64, for compatibility tracking.",
+              "type": "string"
+            },
+            "epoch": {
+              "description": "Shows the epoch number of the affected package, supporting versioning and update tracking.",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the package affected by the advisory, used for identification and management.",
+              "type": "string"
+            },
+            "release": {
+              "description": "Indicates the RPM release number of the affected package, supporting package management and updates.",
+              "type": "string"
+            },
+            "version": {
+              "description": "Displays the upstream version of the affected package, supporting version control and update planning.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": "AffectedPackages",
+        "type": "array"
+      },
+      "2.5.0_v1_UserCreationRequest": {
+        "additionalProperties": false,
+        "description": "Represents the request body to create a new user, including identification, credentials, and abilities for system access and management.",
+        "example": {
+          "abilities": [],
+          "email": "john.doe@example.com",
+          "enabled": true,
+          "fullname": "John Doe",
+          "password": "secure_password",
+          "password_confirmation": "secure_password",
+          "username": "john.doe"
+        },
+        "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/2.5.0_v1_AbilityCollection"
+          },
+          "email": {
+            "description": "The email address of the user to be created, supporting communication and authentication.",
+            "example": "new.user@example.com",
+            "format": "email",
+            "nullable": false,
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Indicates whether the new user is enabled in the system, supporting access control.",
+            "example": true,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "fullname": {
+            "description": "The full name of the user to be created, supporting identification and personalization.",
+            "example": "New User",
+            "nullable": false,
+            "type": "string"
+          },
+          "password": {
+            "description": "The password for the new user, supporting secure authentication and access.",
+            "example": "secure_password",
+            "nullable": false,
+            "type": "string"
+          },
+          "password_confirmation": {
+            "description": "Confirmation of the new user's password, which must match the password field for security.",
+            "example": "secure_password",
+            "nullable": false,
+            "type": "string"
+          },
+          "username": {
+            "description": "The username for the new user, supporting system access and identification.",
+            "example": "john.doe",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "required": [
+          "fullname",
+          "email",
+          "enabled",
+          "password",
+          "password_confirmation",
+          "username"
+        ],
+        "title": "UserCreationRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_RelevantPatch": {
+        "additionalProperties": false,
+        "description": "Represents a software patch that is relevant to the current system or package, including details for update application.",
+        "example": {
+          "advisory_name": "SUSE-SU-2024:0001-1",
+          "advisory_status": "stable",
+          "advisory_synopsis": "Critical security update for OpenSSL",
+          "advisory_type": "security_advisory",
+          "date": "2024-01-15",
+          "id": 1234,
+          "update_date": "2024-01-15"
+        },
+        "properties": {
+          "advisory_name": {
+            "description": "The name of the advisory related to the patch, used for identification and compliance tracking.",
+            "example": "SUSE-SU-2024:0001-1",
+            "type": "string"
+          },
+          "advisory_status": {
+            "description": "Indicates the current status of the advisory, such as stable, pending, or deprecated, for update management.",
+            "example": "stable",
+            "type": "string"
+          },
+          "advisory_synopsis": {
+            "description": "Provides a brief summary of the advisory, outlining the main points and impact of the patch.",
+            "example": "Critical security update for OpenSSL",
+            "type": "string"
+          },
+          "advisory_type": {
+            "description": "Specifies the type of advisory, such as security, bugfix, or enhancement, for classification purposes.",
+            "enum": [
+              "security_advisory",
+              "bugfix",
+              "enhancement"
+            ],
+            "example": "security_advisory",
+            "type": "string"
+          },
+          "date": {
+            "description": "The date when the advisory was issued, providing a timeline for patch application.",
+            "example": "2024-01-15",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the advisory associated with the patch, used for reference and management.",
+            "example": 1234,
+            "type": "integer"
+          },
+          "update_date": {
+            "description": "The date when the advisory was last updated, helping track changes and revisions over time.",
+            "example": "2024-01-15",
+            "type": "string"
+          }
+        },
+        "title": "RelevantPatch",
+        "type": "object"
+      },
+      "2.5.0_v1_NotFound": {
+        "additionalProperties": false,
+        "description": "Represents an error response for a resource not found, providing details about the reason the requested resource could not be located.",
+        "example": {
+          "errors": [
+            {
+              "detail": "The requested resource cannot be found.",
+              "title": "Not Found"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
+              {
+                "detail": "The requested resource cannot be found.",
+                "title": "Not Found"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "description": "Provides a detailed explanation of why the requested resource could not be found, supporting troubleshooting and resolution.",
+                  "example": "The requested resource cannot be found.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short summary indicating the not found status, used for quick identification and error handling.",
+                  "example": "Not Found",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "NotFound",
+        "type": "object"
+      },
+      "2.5.0_v1_DatabasesCollection": {
+        "description": "A list containing all discovered HANA Databases on the target infrastructure, supporting monitoring and management.",
+        "example": [
+          {
+            "database_instances": [],
+            "health": "passing",
+            "id": "9c86eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "inserted_at": "2024-01-15T10:30:00Z",
+            "sid": "HA1",
+            "tags": [],
+            "updated_at": "2024-01-15T12:30:00Z"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_Database"
+        },
+        "title": "DatabasesCollection",
+        "type": "array"
+      },
+      "2.5.0_v1_HealthOverview": {
+        "description": "A list of health summaries for discovered SAP systems, supporting infrastructure monitoring and alerting.",
+        "example": [
+          {
+            "application_cluster_health": "passing",
+            "application_cluster_id": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "cluster_id": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "clusters_health": "passing",
+            "database_cluster_health": "passing",
+            "database_cluster_id": "5a65db74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "database_health": "passing",
+            "database_id": "9c86eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "database_sid": "HA1",
+            "hosts_health": "passing",
+            "id": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "sapsystem_health": "passing",
+            "sid": "HA1",
+            "tenant": "PRD"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_SAPSystemHealthOverview"
+        },
+        "title": "HealthOverview",
+        "type": "array"
+      },
+      "2.5.0_v1_AbilityCollection": {
+        "description": "A list containing all defined abilities available for assignment or management in the platform.",
+        "example": [
+          {
+            "id": 1,
+            "label": "Can do anything",
+            "name": "all",
+            "resource": "all"
+          },
+          {
+            "id": 2,
+            "label": "Cleanup operations for a cluster",
+            "name": "cleanup:request_execution",
+            "resource": "cluster"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_Ability"
+        },
+        "title": "AbilityCollection",
+        "type": "array"
+      },
+      "2.5.0_v1_Conflict": {
+        "additionalProperties": false,
+        "description": "Represents an error response for a resource conflict, providing details about the nature of the conflict encountered.",
+        "example": {
+          "errors": [
+            {
+              "detail": "Conflicting state.",
+              "title": "Conflict has occurred"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
+              {
+                "detail": "Conflicting state.",
+                "title": "Conflict has occurred"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "description": "Provides a detailed explanation of the conflict encountered, supporting troubleshooting and resolution.",
+                  "example": "Conflicting state.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short summary of the conflict type, used for quick identification and error handling.",
+                  "example": "Conflict has occurred",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "Conflict",
+        "type": "object"
+      },
+      "2.5.0_v1_UpdateAlertingSettings": {
+        "description": "Represents the request body for updating alerting settings, including notification and SMTP configuration details for the alerting subsystem.",
+        "example": {
+          "enabled": true,
+          "recipient_email": "admin@example.com",
+          "sender_email": "noreply@example.com"
+        },
+        "properties": {
+          "enabled": {
+            "example": true,
+            "type": "boolean"
+          },
+          "recipient_email": {
+            "example": "admin@example.com",
+            "format": "email",
+            "type": "string"
+          },
+          "sender_email": {
+            "example": "noreply@example.com",
+            "format": "email",
+            "type": "string"
+          },
+          "smtp_password": {
+            "example": "smtp_password",
+            "format": "password",
+            "type": "string"
+          },
+          "smtp_port": {
+            "example": 587,
+            "type": "integer"
+          },
+          "smtp_server": {
+            "example": "smtp.example.com",
+            "type": "string"
+          },
+          "smtp_username": {
+            "example": "smtp_user",
+            "type": "string"
+          }
+        },
+        "title": "UpdateAlertingSettings",
+        "type": "object"
+      },
+      "2.5.0_v1_Host": {
+        "additionalProperties": false,
+        "description": "Represents a discovered host on the target infrastructure, including its configuration, health, and associated resources.",
+        "example": {
+          "agent_version": "1.2.3",
+          "arch": "x86_64",
+          "cluster_host_status": "online",
+          "cluster_id": "123e4567-e89b-12d3-a456-426614174000",
+          "deregistered_at": "2024-01-15T08:00:00Z",
+          "health": "passing",
+          "heartbeat": "passing",
+          "hostname": "hana01",
+          "id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+          "inserted_at": "2024-01-15T09:00:00Z",
+          "ip_addresses": [
+            "192.168.1.100",
+            "2001:db8::1"
+          ],
+          "last_heartbeat_timestamp": "2024-01-15T12:45:00Z",
+          "netmasks": [
+            24,
+            64
+          ],
+          "provider": "azure",
+          "provider_data": {
+            "location": "West Europe",
+            "resource_group": "sap-production-rg",
+            "vm_size": "Standard_E16s_v3"
+          },
+          "saptune_status": {
+            "package_version": "3.1.0"
+          },
+          "selected_checks": [
+            "check_1",
+            "check_2"
+          ],
+          "sles_subscriptions": [],
+          "systemd_units": [
+            {
+              "name": "sapinit",
+              "unit_file_state": "enabled"
+            }
+          ],
+          "tags": [
+            {
+              "resource_id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+              "resource_type": "host",
+              "value": "production"
+            }
+          ],
+          "updated_at": "2024-01-15T12:45:00Z"
+        },
+        "properties": {
+          "agent_version": {
+            "description": "Shows the version of the agent software installed on the host, supporting compatibility and management.",
+            "type": "string"
+          },
+          "arch": {
+            "$ref": "#/components/schemas/2.5.0_v1_HostArchitecture"
+          },
+          "cluster_host_status": {
+            "description": "Shows the current status of the host within its cluster, supporting operational monitoring and management.",
+            "enum": [
+              "online",
+              "offline"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "cluster_id": {
+            "description": "Unique identifier of the cluster to which this host belongs, supporting infrastructure management.",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "deregistered_at": {
+            "description": "The timestamp indicating when the host was last deregistered, supporting audit and lifecycle management.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "heartbeat": {
+            "description": "Indicates the last heartbeat status received from the host, supporting health monitoring and alerting.",
+            "enum": [
+              "critical",
+              "passing",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "hostname": {
+            "description": "The name assigned to the host, used for identification and organization.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the host, used for tracking and management.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "ip_addresses": {
+            "description": "A list of IP addresses assigned to the host, supporting network identification and communication.",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/2.5.0_v1_IPv4"
+                },
+                {
+                  "$ref": "#/components/schemas/2.5.0_v1_IPv6"
+                }
+              ],
+              "description": "Represents an IP address for the host, which may be either IPv4 or IPv6, supporting network connectivity."
+            },
+            "type": "array"
+          },
+          "last_heartbeat_timestamp": {
+            "description": "The timestamp of the last heartbeat received from the host, supporting health monitoring and alerting.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "netmasks": {
+            "description": "A list of netmasks associated with the host's IP addresses, where each netmask corresponds to the position of the IP address in the list.",
+            "items": {
+              "nullable": true,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/2.5.0_v1_SupportedProviders"
+          },
+          "provider_data": {
+            "$ref": "#/components/schemas/2.5.0_v1_ProviderMetadata"
+          },
+          "saptune_status": {
+            "$ref": "#/components/schemas/2.5.0_v1_SaptuneStatus"
+          },
+          "selected_checks": {
+            "description": "A list containing the IDs of checks selected for execution on this host, supporting targeted monitoring and analysis.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sles_subscriptions": {
+            "description": "A list containing all available SLES subscriptions on the host, supporting license management and compliance.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_SlesSubscription"
+            },
+            "type": "array"
+          },
+          "systemd_units": {
+            "description": "A list containing all systemd units present on the host, supporting service management and monitoring.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_SystemdUnit"
+            },
+            "type": "array"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/2.5.0_v1_Tags"
+          },
+          "updated_at": {
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "Host",
+        "type": "object"
+      },
+      "2.5.0_v1_UserItem": {
+        "additionalProperties": false,
+        "description": "User entity in the system.",
+        "example": {
+          "abilities": [],
+          "analytics_enabled": false,
+          "created_at": "2024-01-15T09:00:00Z",
+          "email": "user.item@example.com",
+          "enabled": true,
+          "fullname": "User Item",
+          "id": 1,
+          "idp_user": false,
+          "totp_enabled_at": "2024-01-15T09:00:00Z",
+          "updated_at": "2024-01-15T10:30:00Z",
+          "username": "user.item"
+        },
+        "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/2.5.0_v1_AbilityCollection"
+          },
+          "analytics_enabled": {
+            "description": "Whether user analytics collection is enabled.",
+            "example": false,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "created_at": {
+            "description": "Date of user creation.",
+            "example": "2024-01-15T09:00:00Z",
+            "format": "date-time",
+            "nullable": false,
+            "type": "string"
+          },
+          "email": {
+            "description": "The email address associated with the user, used for communication, authentication, and account management within the system.",
+            "example": "user.item@example.com",
+            "format": "email",
+            "nullable": false,
+            "type": "string"
+          },
+          "enabled": {
+            "description": "User enabled in the system.",
+            "example": true,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "fullname": {
+            "description": "User full name.",
+            "example": "User Item",
+            "nullable": false,
+            "type": "string"
+          },
+          "id": {
+            "description": "User ID.",
+            "nullable": false,
+            "type": "integer"
+          },
+          "idp_user": {
+            "description": "User coming from an external IDP.",
+            "nullable": false,
+            "type": "boolean"
+          },
+          "password_change_requested_at": {
+            "description": "Date of password change request.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "totp_enabled_at": {
+            "description": "Date of TOTP enrollment.",
+            "example": "2024-01-15T09:00:00Z",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Date of user last update.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "username": {
+            "description": "User username.",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "id",
+          "fullname",
+          "email",
+          "created_at"
+        ],
+        "title": "UserItem",
+        "type": "object"
+      },
+      "2.5.0_v1_ActivityLogSettings": {
+        "additionalProperties": false,
+        "description": "Activity Log settings of the current installation.",
+        "example": {
+          "retention_time": {
+            "unit": "day",
+            "value": 30
+          }
+        },
+        "properties": {
+          "retention_time": {
+            "$ref": "#/components/schemas/2.5.0_v1_RetentionTimeSettings"
+          }
+        },
+        "required": [
+          "retention_time"
+        ],
+        "title": "ActivityLogSettings",
+        "type": "object"
+      },
+      "2.5.0_v1_AffectedSystems": {
+        "additionalProperties": false,
+        "description": "Represents the response returned from the get affected systems endpoint, listing all systems affected by advisories.",
+        "example": [
+          {
+            "name": "sap-host-01"
+          },
+          {
+            "name": "sap-host-02"
+          }
+        ],
+        "items": {
+          "description": "Provides metadata for a system affected by an advisory, supporting tracking and management of vulnerabilities.",
+          "properties": {
+            "name": {
+              "description": "The name of the system affected by the advisory, used for identification and management.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": "AffectedSystems",
+        "type": "array"
+      },
+      "2.5.0_v1_ApiKeySettings": {
+        "additionalProperties": false,
+        "description": "Settings for API Key generation.",
+        "example": {
+          "created_at": "2024-01-15T09:00:00Z",
+          "expire_at": "2024-12-31T23:59:59Z",
+          "generated_api_key": "api_key_abcd1234efgh5678ijkl9012mnop3456"
+        },
+        "properties": {
+          "created_at": {
+            "description": "The creation date of api key.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "expire_at": {
+            "description": "The date and time when the API key will expire, supporting security and access control.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "generated_api_key": {
+            "description": "The generated api key from api key settings.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "generated_api_key",
+          "expire_at",
+          "created_at"
+        ],
+        "title": "ApiKeySettings",
+        "type": "object"
+      },
+      "2.5.0_v1_ResourceHealth": {
+        "description": "Represents the detected health status of a resource, indicating whether it is passing, critical, or unknown for monitoring and alerting purposes.",
+        "enum": [
+          "passing",
+          "warning",
+          "critical",
+          "unknown"
+        ],
+        "example": "passing",
+        "nullable": true,
+        "title": "ResourceHealth",
+        "type": "string"
+      },
+      "2.5.0_v1_GcpProviderData": {
+        "additionalProperties": false,
+        "description": "Metadata detected for resources running on Google Cloud Platform (GCP), including disk, image, instance, and network details for infrastructure management.",
+        "example": {
+          "disk_number": 2,
+          "image": "sles-15-sp3-sap-v20220126",
+          "instance_name": "sap-hana-instance",
+          "machine_type": "n1-highmem-32",
+          "network": "default",
+          "project_id": "my-sap-project-123456",
+          "zone": "europe-west1-b"
+        },
+        "properties": {
+          "disk_number": {
+            "type": "integer"
+          },
+          "image": {
+            "type": "string"
+          },
+          "instance_name": {
+            "type": "string"
+          },
+          "machine_type": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "zone": {
+            "type": "string"
+          }
+        },
+        "title": "GcpProviderData",
+        "type": "object"
+      },
+      "2.5.0_v1_HostMemoryChart": {
+        "additionalProperties": false,
+        "description": "Represents a time series chart that provides detailed information about the memory usage of a host over a period of time.",
+        "example": {
+          "ram_cache_and_buffer": {
+            "label": "Cache and Buffer",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 2147483648
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 2147483648
+              }
+            ]
+          },
+          "ram_free": {
+            "label": "Free RAM",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 4294967296
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 4194967296
+              }
+            ]
+          },
+          "ram_total": {
+            "label": "Total RAM",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 16777216000
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 16777216000
+              }
+            ]
+          },
+          "ram_used": {
+            "label": "Used RAM",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 10485760000
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 10585760000
+              }
+            ]
+          },
+          "swap_used": {
+            "label": "Used Swap",
+            "series": [
+              {
+                "timestamp": "2024-01-15T10:00:00Z",
+                "value": 1073741824
+              },
+              {
+                "timestamp": "2024-01-15T10:01:00Z",
+                "value": 1073741824
+              }
+            ]
+          }
+        },
+        "properties": {
+          "ram_cache_and_buffer": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "ram_free": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "ram_total": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "ram_used": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          },
+          "swap_used": {
+            "$ref": "#/components/schemas/2.5.0_v1_ChartTimeSeries"
+          }
+        },
+        "title": "HostMemoryChart",
+        "type": "object"
+      },
+      "2.5.0_v1_PacemakerClustersCollection": {
+        "description": "A list containing all Pacemaker Clusters discovered on the target infrastructure, supporting monitoring and management.",
+        "example": [
+          {
+            "additional_sids": [
+              "ERS",
+              "ASCS"
+            ],
+            "cib_last_written": "2024-01-15T10:30:00Z",
+            "health": "passing",
+            "hosts_number": 2,
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "inserted_at": "2024-01-15T09:00:00Z",
+            "name": "hana_cluster",
+            "provider": "azure",
+            "resources_number": 10,
+            "selected_checks": [
+              "check_1",
+              "check_2"
+            ],
+            "sid": "PRD",
+            "type": "hana_scale_up",
+            "updated_at": "2024-01-15T10:30:00Z"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_PacemakerCluster"
+        },
+        "title": "PacemakerClustersCollection",
+        "type": "array"
+      },
+      "2.5.0_v1_StartStopParams": {
+        "additionalProperties": false,
+        "description": "Parameters for starting or stopping a SAP instance, including options for controlling operation timing.",
+        "example": {
+          "timeout": 300
+        },
+        "properties": {
+          "timeout": {
+            "description": "Specifies the time in seconds to wait for the SAP instance to complete the start or stop operation.",
+            "example": 300,
+            "type": "number"
+          }
+        },
+        "title": "StartStopParams",
+        "type": "object"
+      },
+      "2.5.0_v1_ActivityLog": {
+        "description": "Represents the activity log for the current installation, providing a comprehensive record of platform events and actions.",
+        "example": {
+          "data": [
+            {
+              "actor": "system",
+              "id": "123e4567-e89b-12d3-a456-426614174000",
+              "metadata": {
+                "host_id": "456e7890-e89b-12d3-a456-426614174001"
+              },
+              "occurred_on": "2024-01-15T10:30:00Z",
+              "severity": "info",
+              "type": "host_registered"
+            }
+          ],
+          "pagination": {
+            "end_cursor": "cursor_end",
+            "first": 10,
+            "has_next_page": false,
+            "has_previous_page": false,
+            "last": 5,
+            "start_cursor": "cursor_start"
+          }
+        },
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/2.5.0_v1_ActivityLogEntries"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/2.5.0_v1_Pagination"
+          }
+        },
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "title": "ActivityLog",
+        "type": "object"
+      },
+      "2.5.0_v1_UserUpdateRequest": {
+        "additionalProperties": false,
+        "description": "Represents the request body to update an existing user, including identification, credentials, abilities, and TOTP settings for system access and management.",
+        "example": {
+          "abilities": [],
+          "email": "admin.user@example.com",
+          "enabled": true,
+          "fullname": "Admin User",
+          "password": "new_secure_password123",
+          "password_confirmation": "new_secure_password123"
+        },
+        "properties": {
+          "abilities": {
+            "$ref": "#/components/schemas/2.5.0_v1_AbilityCollection"
+          },
+          "email": {
+            "description": "The email address of the user to be updated, supporting communication and authentication.",
+            "example": "admin.user@example.com",
+            "format": "email",
+            "nullable": false,
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Indicates whether the user is enabled in the system, supporting access control.",
+            "example": true,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "fullname": {
+            "description": "The full name of the user to be updated, supporting identification and personalization.",
+            "example": "Admin User",
+            "nullable": false,
+            "type": "string"
+          },
+          "password": {
+            "description": "The new password for the user, supporting secure authentication and access.",
+            "example": "new_secure_password123",
+            "nullable": false,
+            "type": "string"
+          },
+          "password_confirmation": {
+            "description": "Confirmation of the user's new password, which must match the password field for security.",
+            "example": "new_secure_password123",
+            "nullable": false,
+            "type": "string"
+          },
+          "totp_disabled": {
+            "description": "Indicates that the TOTP feature is disabled for the user. The only accepted value here is 'true', supporting multi-factor authentication management.",
+            "example": true,
+            "nullable": false,
+            "type": "boolean"
+          }
+        },
+        "title": "UserUpdateRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_AwsProviderData": {
+        "additionalProperties": false,
+        "description": "Metadata detected for resources running on Amazon Web Services (AWS), including account, instance, and network details for infrastructure management.",
+        "example": {
+          "account_id": "123456789012",
+          "ami_id": "ami-0123456789abcdef0",
+          "availability_zone": "us-west-2a",
+          "data_disk_number": 3,
+          "instance_id": "i-0123456789abcdef0",
+          "instance_type": "r5.4xlarge",
+          "region": "us-west-2",
+          "vpc_id": "vpc-0123456789abcdef0"
+        },
+        "properties": {
+          "account_id": {
+            "type": "string"
+          },
+          "ami_id": {
+            "type": "string"
+          },
+          "availability_zone": {
+            "type": "string"
+          },
+          "data_disk_number": {
+            "type": "integer"
+          },
+          "instance_id": {
+            "type": "string"
+          },
+          "instance_type": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "vpc_id": {
+            "type": "string"
+          }
+        },
+        "title": "AwsProviderData",
+        "type": "object"
+      },
+      "2.5.0_v1_ClusterMaintenanceChangeParams": {
+        "additionalProperties": false,
+        "description": "Represents the parameters for changing cluster maintenance state, including logic for resource and node prioritization. If neither resource_id nor node_id are provided, the entire cluster maintenance state is changed. Resource_id takes precedence over node_id.",
+        "example": {
+          "maintenance": true,
+          "node_id": "node_1",
+          "resource_id": "resource_1"
+        },
+        "properties": {
+          "maintenance": {
+            "description": "Indicates the desired maintenance state to apply to the cluster, node, or resource, supporting operational management.",
+            "type": "boolean"
+          },
+          "node_id": {
+            "description": "Unique identifier of the cluster node whose maintenance state should be changed, supporting targeted operations.",
+            "type": "string"
+          },
+          "resource_id": {
+            "description": "Unique identifier of the cluster resource whose maintenance state should be changed, supporting targeted operations.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "maintenance"
+        ],
+        "title": "ClusterMaintenanceChangeParams",
+        "type": "object"
+      },
+      "2.5.0_v1_HanaClusterDetails": {
+        "additionalProperties": false,
+        "description": "Provides detailed information about a HANA Pacemaker Cluster, including replication, health, and resource status.",
+        "example": {
+          "fencing_type": "external/sbd",
+          "nodes": [
+            {
+              "attributes": {
+                "hana_prd_op_mode": "logreplay"
+              },
+              "hana_status": "Primary",
+              "name": "hana01",
+              "site": "NUREMBERG",
+              "virtual_ip": "192.168.1.10"
+            }
+          ],
+          "sbd_devices": [
+            {
+              "device": "/dev/disk/by-id/scsi-SLIO-ORG_disk_01",
+              "status": "healthy"
+            }
+          ],
+          "secondary_sync_state": "SOK",
+          "sr_health_state": "4",
+          "stopped_resources": [],
+          "system_replication_mode": "sync",
+          "system_replication_operation_mode": "logreplay"
+        },
+        "properties": {
+          "fencing_type": {
+            "description": "Specifies the type of fencing used in the cluster, supporting high availability and fault tolerance.",
+            "type": "string"
+          },
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_HanaClusterNode"
+            },
+            "type": "array"
+          },
+          "sbd_devices": {
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_SbdDevice"
+            },
+            "type": "array"
+          },
+          "secondary_sync_state": {
+            "description": "Displays the synchronization state of the secondary node in the HANA cluster, supporting monitoring and management.",
+            "type": "string"
+          },
+          "sr_health_state": {
+            "description": "Indicates the health status of system replication in the HANA cluster, supporting operational decisions.",
+            "type": "string"
+          },
+          "stopped_resources": {
+            "description": "A list containing resources that are currently stopped in the HANA cluster, supporting troubleshooting and recovery.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_ClusterResource"
+            },
+            "type": "array"
+          },
+          "system_replication_mode": {
+            "description": "Indicates the replication mode used by the HANA system, supporting high availability and disaster recovery.",
+            "type": "string"
+          },
+          "system_replication_operation_mode": {
+            "description": "Shows the operation mode for system replication, providing context for cluster synchronization and failover.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "nodes"
+        ],
+        "title": "HanaClusterDetails",
+        "type": "object"
+      },
+      "2.5.0_v1_AzureProviderData": {
+        "additionalProperties": false,
+        "description": "Metadata detected for resources running on Microsoft Azure, including details about resource group, location, VM size, and more.",
+        "example": {
+          "admin_username": "azureuser",
+          "data_disk_number": 4,
+          "location": "West Europe",
+          "offer": "SLES-SAP",
+          "resource_group": "sap-production-rg",
+          "sku": "15-SP3",
+          "vm_size": "Standard_E16s_v3"
+        },
+        "properties": {
+          "admin_username": {
+            "type": "string"
+          },
+          "data_disk_number": {
+            "type": "integer"
+          },
+          "location": {
+            "type": "string"
+          },
+          "offer": {
+            "type": "string"
+          },
+          "resource_group": {
+            "type": "string"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "vm_size": {
+            "type": "string"
+          }
+        },
+        "title": "AzureProviderData",
+        "type": "object"
+      },
+      "2.5.0_v1_UpgradablePackage": {
+        "additionalProperties": false,
+        "description": "Represents a software package that can be upgraded to a newer version, including relevant metadata for update management.",
+        "example": {
+          "arch": "x86_64",
+          "from_epoch": "0",
+          "from_release": "1.1",
+          "from_version": "1.0.0",
+          "name": "openssl",
+          "to_epoch": "0",
+          "to_package_id": 5678,
+          "to_release": "1.2",
+          "to_version": "1.1.1"
+        },
+        "properties": {
+          "arch": {
+            "description": "Specifies the architecture type for the upgradable package, such as x86_64 or arm64.",
+            "example": "x86_64",
+            "type": "string"
+          },
+          "from_epoch": {
+            "description": "Indicates the epoch value from which the package is being upgraded, used for version control.",
+            "example": "0",
+            "type": "string"
+          },
+          "from_release": {
+            "description": "Shows the release version from which the package is being upgraded, aiding in update tracking.",
+            "example": "1.1",
+            "type": "string"
+          },
+          "from_version": {
+            "description": "Displays the version number from which the package is being upgraded, providing historical context.",
+            "example": "1.0.0",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the software package that is eligible for upgrade, used for identification and management.",
+            "example": "openssl",
+            "type": "string"
+          },
+          "to_epoch": {
+            "description": "Indicates the epoch value to which the package will be upgraded, supporting version management.",
+            "example": "0",
+            "type": "string"
+          },
+          "to_package_id": {
+            "description": "Unique identifier for the package version being upgraded to, used for tracking updates.",
+            "example": 5678,
+            "type": "integer"
+          },
+          "to_release": {
+            "description": "Shows the release version to which the package will be upgraded, aiding in update planning.",
+            "example": "1.2",
+            "type": "string"
+          },
+          "to_version": {
+            "description": "Displays the version number to which the package will be upgraded, providing future context.",
+            "example": "1.1.1",
+            "type": "string"
+          }
+        },
+        "title": "UpgradablePackage",
+        "type": "object"
+      },
+      "2.5.0_v1_AlertingSettings": {
+        "description": "Settings for the alerting sub-system.",
+        "example": {
+          "enabled": true,
+          "enforced_from_env": false,
+          "recipient_email": "admin@example.com",
+          "sender_email": "noreply@example.com",
+          "smtp_port": 587,
+          "smtp_server": "smtp.example.com",
+          "smtp_username": "smtp_user"
+        },
+        "properties": {
+          "enabled": {
+            "example": true,
+            "type": "boolean"
+          },
+          "enforced_from_env": {
+            "example": false,
+            "type": "boolean"
+          },
+          "recipient_email": {
+            "example": "admin@example.com",
+            "type": "string"
+          },
+          "sender_email": {
+            "example": "noreply@example.com",
+            "type": "string"
+          },
+          "smtp_port": {
+            "example": 587,
+            "type": "integer"
+          },
+          "smtp_server": {
+            "example": "smtp.example.com",
+            "type": "string"
+          },
+          "smtp_username": {
+            "example": "smtp_user",
+            "type": "string"
+          }
+        },
+        "required": [
+          "enabled",
+          "sender_email",
+          "recipient_email",
+          "smtp_server",
+          "smtp_port",
+          "smtp_username",
+          "enforced_from_env"
+        ],
+        "title": "AlertingSettings",
+        "type": "object"
+      },
+      "2.5.0_v1_RetentionTimeSettings": {
+        "additionalProperties": false,
+        "description": "Retention Time settings of the Activity Log.",
+        "example": {
+          "unit": "day",
+          "value": 30
+        },
+        "properties": {
+          "unit": {
+            "description": "The retention duration unit, that is used in conjunction with the retention time period.",
+            "enum": [
+              "day",
+              "week",
+              "month",
+              "year"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "description": "The integer retention duration, that is used in conjunction with the retention time unit.",
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "value",
+          "unit"
+        ],
+        "title": "RetentionTimeSettings",
+        "type": "object"
+      },
+      "2.5.0_v1_ErrataDetails": {
+        "additionalProperties": false,
+        "description": "Provides detailed information for the erratum that matches the specified advisory name, supporting update management.",
+        "example": {
+          "advisory_status": "stable",
+          "description": "This update fixes critical security vulnerabilities in OpenSSL.",
+          "errata_from": "security@suse.de",
+          "id": 12345,
+          "issue_date": "2024-01-15",
+          "last_modified_date": "2024-01-15",
+          "notes": "Please restart affected services after applying this update.",
+          "product": "SLES",
+          "reboot_suggested": false,
+          "references": "https://bugzilla.suse.com/show_bug.cgi?id=123456",
+          "release": 1,
+          "restart_suggested": true,
+          "solution": "Run zypper patch to apply this update.",
+          "synopsis": "Critical security update for OpenSSL",
+          "topic": "OpenSSL security update",
+          "type": "security_advisory",
+          "update_date": "2024-01-15",
+          "vendor_advisory": "SUSE-SU-2024:0001-1"
+        },
+        "properties": {
+          "advisory_status": {
+            "description": "Shows the current status of the advisory, such as stable or pending, for update management.",
+            "type": "string"
+          },
+          "description": {
+            "description": "A detailed explanation of the advisory, outlining its purpose and impact.",
+            "type": "string"
+          },
+          "errata_from": {
+            "description": "Indicates the source of the errata, supporting traceability and compliance.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the advisory, used for reference and management.",
+            "format": "int",
+            "type": "number"
+          },
+          "issue_date": {
+            "description": "The date when the advisory was issued, providing historical context for the erratum.",
+            "format": "date",
+            "type": "string"
+          },
+          "last_modified_date": {
+            "description": "The date when the advisory was last modified, supporting update tracking for the erratum.",
+            "format": "date",
+            "type": "string"
+          },
+          "notes": {
+            "description": "Additional notes regarding the advisory, providing extra context or instructions.",
+            "type": "string"
+          },
+          "product": {
+            "description": "The product associated with the advisory, used for identification and management.",
+            "type": "string"
+          },
+          "reboot_suggested": {
+            "description": "A boolean flag signaling whether a system reboot is advisable following the application of the errata. Typical example is upon kernel update.",
+            "type": "boolean"
+          },
+          "references": {
+            "description": "Lists references related to the advisory, supporting further research and validation.",
+            "type": "string"
+          },
+          "release": {
+            "description": "Indicates the release number associated with the advisory, supporting version tracking.",
+            "format": "int",
+            "type": "number"
+          },
+          "restart_suggested": {
+            "description": "A boolean flag signaling a weather reboot of the package manager is advisable following the application of the errata. This is commonly used to address update stack issues before proceeding with other updates.",
+            "type": "boolean"
+          },
+          "solution": {
+            "description": "Describes the recommended solution or remediation for the advisory, supporting resolution.",
+            "type": "string"
+          },
+          "synopsis": {
+            "description": "A brief summary of the advisory, outlining its main points and impact.",
+            "type": "string"
+          },
+          "topic": {
+            "description": "The topic covered by the advisory, providing context for the update or fix.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Specifies the type of advisory, such as security or bugfix, for classification purposes.",
+            "type": "string"
+          },
+          "update_date": {
+            "description": "The date when the advisory was last updated, helping track changes and revisions for the erratum.",
+            "format": "date",
+            "type": "string"
+          },
+          "vendor_advisory": {
+            "description": "Information provided by the vendor regarding the advisory, supporting compliance and tracking.",
+            "type": "string"
+          }
+        },
+        "title": "ErrataDetails",
+        "type": "object"
+      },
+      "2.5.0_v1_CreateAlertingSettings": {
+        "description": "Represents the request body for creating alerting settings, including notification and SMTP configuration details for the alerting subsystem.",
+        "example": {
+          "enabled": true,
+          "recipient_email": "admin@example.com",
+          "sender_email": "noreply@example.com",
+          "smtp_password": "smtp_password",
+          "smtp_port": 587,
+          "smtp_server": "smtp.example.com",
+          "smtp_username": "smtp_user"
+        },
+        "properties": {
+          "enabled": {
+            "description": "Indicates whether the alerting subsystem is enabled, allowing notifications to be sent when events occur.",
+            "example": true,
+            "type": "boolean"
+          },
+          "recipient_email": {
+            "description": "The email address that will receive alert notifications, ensuring timely communication of important events.",
+            "example": "admin@example.com",
+            "format": "email",
+            "type": "string"
+          },
+          "sender_email": {
+            "description": "The email address used as the sender for alert notifications, supporting identification and delivery.",
+            "example": "noreply@example.com",
+            "format": "email",
+            "type": "string"
+          },
+          "smtp_password": {
+            "description": "The password used to authenticate with the SMTP server for secure email delivery.",
+            "example": "smtp_password",
+            "format": "password",
+            "type": "string"
+          },
+          "smtp_port": {
+            "description": "The port number used to connect to the SMTP server for sending alert notifications.",
+            "example": 587,
+            "type": "integer"
+          },
+          "smtp_server": {
+            "description": "The SMTP server address used to send alert emails, supporting reliable notification delivery.",
+            "example": "smtp.example.com",
+            "type": "string"
+          },
+          "smtp_username": {
+            "description": "The username used to authenticate with the SMTP server when sending alert emails.",
+            "example": "smtp_user",
+            "type": "string"
+          }
+        },
+        "required": [
+          "enabled",
+          "sender_email",
+          "recipient_email",
+          "smtp_server",
+          "smtp_port",
+          "smtp_username",
+          "smtp_password"
+        ],
+        "title": "CreateAlertingSettings",
+        "type": "object"
+      },
+      "2.5.0_v1_DatabaseInstances": {
+        "description": "A list containing all database instances that are part of a complete SAP System or a standalone HANA Database, supporting system management.",
+        "example": [
+          {
+            "database_id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+            "features": "HDB|HDB_WORKER",
+            "health": "passing",
+            "host_id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+            "http_port": 8000,
+            "https_port": 8443,
+            "inserted_at": "2024-01-15T10:30:00Z",
+            "instance_hostname": "hanadb01",
+            "instance_number": "00",
+            "sap_system_id": "290e8a7b-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+            "sid": "PRD",
+            "start_priority": "0.3",
+            "system_replication": "ENABLED",
+            "system_replication_status": "ACTIVE",
+            "tenant": "SYSTEMDB"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_DatabaseInstance"
+        },
+        "title": "DatabaseInstances",
+        "type": "array"
+      },
+      "2.5.0_v1_UserTOTPEnrollmentConfirmPayload": {
+        "additionalProperties": false,
+        "description": "Trento User TOTP enrollment completed payload.",
+        "example": {
+          "totp_enabled_at": "2024-01-15T09:00:00Z"
+        },
+        "properties": {
+          "totp_enabled_at": {
+            "description": "Date of TOTP enrollment.",
+            "example": "2024-01-15T09:00:00Z",
+            "format": "date-time",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "required": [
+          "totp_enabled_at"
+        ],
+        "title": "UserTOTPEnrollmentConfirmPayload",
+        "type": "object"
+      },
+      "2.5.0_v1_HostArchitecture": {
+        "description": "Represents the detected architecture type of a host, such as x86_64 or arm64, supporting compatibility and infrastructure management.",
+        "enum": [
+          "x86_64",
+          "ppc64le",
+          "s390x",
+          "unknown"
+        ],
+        "example": "x86_64",
+        "nullable": false,
+        "title": "HostArchitecture",
+        "type": "string"
+      },
+      "2.5.0_v1_SAPSystemHealthOverview": {
+        "additionalProperties": false,
+        "description": "Provides an overview of the health status for a discovered SAP system and its components, supporting infrastructure monitoring and alerting.",
+        "example": {
+          "application_cluster_health": "passing",
+          "application_cluster_id": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "cluster_id": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "clusters_health": "passing",
+          "database_cluster_health": "passing",
+          "database_cluster_id": "5a65db74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "database_health": "passing",
+          "database_id": "9c86eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "database_sid": "HA1",
+          "hosts_health": "passing",
+          "id": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+          "sapsystem_health": "passing",
+          "sid": "HA1",
+          "tenant": "PRD"
+        },
+        "properties": {
+          "application_cluster_health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "application_cluster_id": {
+            "description": "Unique identifier for the application cluster associated with this SAP system, supporting resource mapping.",
+            "example": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "cluster_id": {
+            "deprecated": true,
+            "description": "Unique identifier for the cluster associated with this SAP system, supporting infrastructure mapping.",
+            "example": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "clusters_health": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+              },
+              {
+                "deprecated": true
+              }
+            ]
+          },
+          "database_cluster_health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "database_cluster_id": {
+            "description": "Unique identifier for the database cluster associated with this SAP system, supporting resource mapping.",
+            "example": "5a65db74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "database_health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "database_id": {
+            "description": "Unique identifier for the database associated with this SAP system, supporting resource tracking and management.",
+            "example": "9c86eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "database_sid": {
+            "description": "Database SID.",
+            "example": "HA1",
+            "type": "string"
+          },
+          "hosts_health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "id": {
+            "description": "Unique identifier for the SAP system, supporting resource tracking and management.",
+            "example": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "format": "uuid",
+            "type": "string"
+          },
+          "sapsystem_health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "sid": {
+            "description": "The SAP system identifier (SID) for this system, supporting system identification.",
+            "example": "HA1",
+            "type": "string"
+          },
+          "tenant": {
+            "deprecated": true,
+            "description": "Tenant database SID.",
+            "example": "PRD",
+            "type": "string"
+          }
+        },
+        "title": "SAPSystemHealthOverview",
+        "type": "object"
+      },
+      "2.5.0_v1_HostOperationParams": {
+        "description": "Represents the parameters for a host operation request, including actions such as applying Saptune solutions for system management.",
+        "example": {
+          "solution": "HANA"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_SaptuneSolutionApplyParams"
+          }
+        ],
+        "title": "HostOperationParams",
+        "type": "object"
+      },
+      "2.5.0_v1_ChecksSelectionRequest": {
+        "additionalProperties": false,
+        "description": "Represents a request containing a list of checks to be executed on the target infrastructure, supporting automated validation and compliance.",
+        "example": {
+          "checks": [
+            "check_1",
+            "check_2",
+            "check_3"
+          ]
+        },
+        "properties": {
+          "checks": {
+            "description": "A list of check identifiers specifying which checks should be executed as part of the request.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "checks"
+        ],
+        "title": "ChecksSelectionRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_SaptuneStaging": {
+        "additionalProperties": false,
+        "description": "Represents saptune staging data, including enabled state, staged notes, and solution identifiers for system configuration and compliance.",
+        "example": {
+          "enabled": true,
+          "notes": [
+            "1410736"
+          ],
+          "solutions_ids": [
+            "HANA"
+          ]
+        },
+        "properties": {
+          "enabled": {
+            "description": "Indicates whether saptune staging is enabled, supporting system configuration and compliance management.",
+            "type": "boolean"
+          },
+          "notes": {
+            "description": "A list of staged saptune note identifiers, supporting configuration and compliance tracking.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "solutions_ids": {
+            "description": "A list of staged saptune solution identifiers, supporting configuration and compliance tracking.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "title": "SaptuneStaging",
+        "type": "object"
+      },
+      "2.5.0_v1_PreconditionRequired": {
+        "additionalProperties": false,
+        "description": "Error response returned when a required precondition for the request is missing, such as the absence of an If-Match header for conditional operations.",
+        "example": {
+          "errors": [
+            {
+              "detail": "Request needs to be conditional, please provide If-Match header.",
+              "title": "Precondition Required"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "description": "A list of error objects describing why a required precondition for the request was missing, such as missing headers for conditional operations.",
+            "example": [
+              {
+                "detail": "Request needs to be conditional, please provide If-Match header.",
+                "title": "Precondition Required"
+              }
+            ],
+            "items": {
+              "description": "Details about a specific error encountered when a required precondition is missing, including a human-readable message and error title.",
+              "properties": {
+                "detail": {
+                  "description": "A message describing the reason for the missing precondition, such as the absence of a required header for conditional requests.",
+                  "example": "Request needs to be conditional, please provide If-Match header.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short title summarizing the error encountered when the required precondition is missing.",
+                  "example": "Precondition Required",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "PreconditionRequired",
+        "type": "object"
+      },
+      "2.5.0_v1_UserProfileUpdateRequest": {
+        "additionalProperties": false,
+        "description": "Request body to update a user profile.",
+        "example": {
+          "analytics_enabled": true,
+          "current_password": "current_password123",
+          "email": "updated.email@example.com",
+          "fullname": "John Updated Doe",
+          "password": "new_secure_password123",
+          "password_confirmation": "new_secure_password123"
+        },
+        "properties": {
+          "analytics_enabled": {
+            "description": "Whether user analytics collection is enabled.",
+            "example": false,
+            "nullable": false,
+            "type": "boolean"
+          },
+          "current_password": {
+            "description": "User current password, used to set a new password.",
+            "example": "current_password123",
+            "nullable": false,
+            "type": "string"
+          },
+          "email": {
+            "description": "User email.",
+            "example": "updated.email@example.com",
+            "format": "email",
+            "nullable": false,
+            "type": "string"
+          },
+          "fullname": {
+            "description": "User full name.",
+            "example": "John Updated Doe",
+            "nullable": false,
+            "type": "string"
+          },
+          "password": {
+            "description": "User new password.",
+            "example": "new_secure_password123",
+            "nullable": false,
+            "type": "string"
+          },
+          "password_confirmation": {
+            "description": "User new password, should be the same as password field.",
+            "example": "new_secure_password123",
+            "nullable": false,
+            "type": "string"
+          }
+        },
+        "title": "UserProfileUpdateRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_SbdDevice": {
+        "additionalProperties": false,
+        "description": "Represents a SBD device used for fencing and high availability in cluster environments.",
+        "example": {
+          "device": "/dev/disk/by-id/scsi-SLIO-ORG_disk_01",
+          "status": "healthy"
+        },
+        "properties": {
+          "device": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "title": "SbdDevice",
+        "type": "object"
+      },
+      "2.5.0_v1_CVEs": {
+        "additionalProperties": false,
+        "description": "Provides a list of CVEs that are applicable to the errata associated with the specified advisory name, supporting vulnerability management.",
+        "example": [
+          "CVE-2024-1234",
+          "CVE-2024-5678"
+        ],
+        "items": {
+          "description": "Represents a fix for a publicly known security vulnerability, including details for remediation and compliance.",
+          "type": "string"
+        },
+        "title": "CVEs",
+        "type": "array"
+      },
+      "2.5.0_v1_HanaClusterNode": {
+        "additionalProperties": false,
+        "description": "Represents a node in a HANA cluster, including its attributes, status, and associated resources for high availability.",
+        "example": {
+          "attributes": {
+            "hana_prd_op_mode": "logreplay",
+            "hana_prd_srmode": "sync"
+          },
+          "hana_status": "Primary",
+          "name": "hana01",
+          "resources": [
+            {
+              "fail_count": 0,
+              "id": "rsc_SAPHana_PRD_HDB00",
+              "role": "Master",
+              "status": "running",
+              "type": "ocf::suse:SAPHana"
+            }
+          ],
+          "site": "NUREMBERG",
+          "virtual_ip": "192.168.1.10"
+        },
+        "properties": {
+          "attributes": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Attributes describing the configuration and operational state of the cluster node, supporting management and monitoring.",
+            "type": "object"
+          },
+          "hana_status": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "resources": {
+            "description": "A list containing resources associated with the HANA cluster node, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_ClusterResource"
+            },
+            "type": "array"
+          },
+          "site": {
+            "type": "string"
+          },
+          "virtual_ip": {
+            "type": "string"
+          }
+        },
+        "title": "HanaClusterNode",
+        "type": "object"
+      },
+      "2.5.0_v1_SaptuneService": {
+        "additionalProperties": false,
+        "description": "Represents a saptune service, including its name, enabled state, and active state for system tuning and monitoring.",
+        "example": {
+          "active": "active",
+          "enabled": "enabled",
+          "name": "saptune"
+        },
+        "properties": {
+          "active": {
+            "description": "Indicates whether the saptune service is currently active, supporting system health and status tracking.",
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Indicates whether the saptune service is enabled, supporting system configuration and monitoring.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the saptune service, supporting identification and management of system tuning components.",
+            "type": "string"
+          }
+        },
+        "title": "SaptuneService",
+        "type": "object"
+      },
+      "2.5.0_v1_AvailableSoftwareUpdatesResponse": {
+        "additionalProperties": false,
+        "description": "Represents the response returned from the available software updates endpoint, including details about upgradable packages and relevant patches.",
+        "example": {
+          "relevant_patches": [
+            {
+              "advisory_name": "SUSE-SU-2024:0001-1",
+              "advisory_status": "stable",
+              "advisory_synopsis": "Critical security update for OpenSSL",
+              "advisory_type": "security_advisory",
+              "date": "2024-01-15",
+              "id": 1234,
+              "update_date": "2024-01-15"
+            }
+          ],
+          "upgradable_packages": [
+            {
+              "arch": "x86_64",
+              "from_epoch": "0",
+              "from_release": "1.1",
+              "from_version": "1.0.0",
+              "name": "openssl",
+              "to_epoch": "0",
+              "to_package_id": 5678,
+              "to_release": "1.2",
+              "to_version": "1.1.1"
+            }
+          ]
+        },
+        "properties": {
+          "relevant_patches": {
+            "description": "A list containing all relevant software patches applicable to the host, supporting maintenance and compliance.",
+            "example": [
+              {
+                "advisory_name": "SUSE-SU-2024:0001-1",
+                "advisory_status": "stable",
+                "advisory_synopsis": "Critical security update for OpenSSL",
+                "advisory_type": "security_advisory",
+                "date": "2024-01-15",
+                "id": 1234,
+                "update_date": "2024-01-15"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_RelevantPatch"
+            },
+            "type": "array"
+          },
+          "upgradable_packages": {
+            "description": "A list containing all software packages on the host that are eligible for upgrade, supporting system updates.",
+            "example": [
+              {
+                "arch": "x86_64",
+                "from_epoch": "0",
+                "from_release": "1.1",
+                "from_version": "1.0.0",
+                "name": "openssl",
+                "to_epoch": "0",
+                "to_package_id": 5678,
+                "to_release": "1.2",
+                "to_version": "1.1.1"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_UpgradablePackage"
+            },
+            "type": "array"
+          }
+        },
+        "title": "AvailableSoftwareUpdatesResponse",
+        "type": "object"
+      },
+      "2.5.0_v1_IPv6": {
+        "description": "Represents the format of an IPv6 address, supporting modern network identification and communication.",
+        "example": "2001:db8::1",
+        "format": "ipv6",
+        "title": "IPv6",
+        "type": "string"
+      },
+      "2.5.0_v1_UnprocessableEntity": {
+        "additionalProperties": false,
+        "description": "Error response returned when the server cannot process the request due to semantic errors, such as invalid or missing values in the payload.",
+        "example": {
+          "errors": [
+            {
+              "detail": "null value where string expected",
+              "title": "Invalid value"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "description": "A list of error objects describing why the request could not be processed, such as semantic errors or invalid values in the payload.",
+            "example": [
+              {
+                "detail": "null value where string expected",
+                "title": "Invalid value"
+              }
+            ],
+            "items": {
+              "description": "Details about a specific error encountered when the request is unprocessable, including a human-readable message and error title.",
+              "properties": {
+                "detail": {
+                  "description": "A message describing the reason for the unprocessable entity error, such as invalid or missing values in the payload.",
+                  "example": "null value where string expected",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short title summarizing the error encountered when the request cannot be processed due to semantic issues.",
+                  "example": "Invalid value",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "detail"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "errors"
+        ],
+        "title": "UnprocessableEntity",
+        "type": "object"
+      },
+      "2.5.0_v1_AdvisoryFixes": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "Represents the response returned from the get advisory fixes endpoint, detailing all fixes for advisories in the system.",
+        "example": {
+          "CVE-2024-1234": "Fixed in OpenSSL 1.1.1w",
+          "CVE-2024-5678": "Fixed in OpenSSL 3.0.8"
+        },
+        "title": "AdvisoryFixes",
+        "type": "object"
+      },
+      "2.5.0_v1_OperationAccepted": {
+        "additionalProperties": false,
+        "description": "Indicates that the requested operation has been authorized and accepted for processing, providing confirmation and tracking information.",
+        "example": {
+          "operation_id": "123e4567-e89b-12d3-a456-426614174000"
+        },
+        "properties": {
+          "operation_id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "operation_id"
+        ],
+        "title": "OperationAccepted",
+        "type": "object"
+      },
+      "2.5.0_v1_ProviderMetadata": {
+        "description": "Represents detected metadata for any supported cloud provider, including AWS, Azure, or GCP, to support infrastructure identification and management.",
+        "example": {
+          "admin_username": "azureuser",
+          "data_disk_number": 4,
+          "location": "West Europe",
+          "offer": "SLES-SAP",
+          "resource_group": "sap-production-rg",
+          "sku": "15-SP3",
+          "vm_size": "Standard_E16s_v3"
+        },
+        "nullable": true,
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_AwsProviderData"
+          },
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_AzureProviderData"
+          },
+          {
+            "$ref": "#/components/schemas/2.5.0_v1_GcpProviderData"
+          }
+        ],
+        "title": "ProviderMetadata",
+        "type": "object"
+      },
+      "2.5.0_v1_SaptuneSolution": {
+        "additionalProperties": false,
+        "description": "Represents a saptune solution, including its identifier, associated notes, and whether it is partially applied for system tuning and compliance.",
+        "example": {
+          "id": "HANA",
+          "notes": [
+            "1410736",
+            "1657417"
+          ],
+          "partial": false
+        },
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the saptune solution, supporting tracking and management of system tuning configurations.",
+            "type": "string"
+          },
+          "notes": {
+            "description": "A list of note identifiers associated with this saptune solution, supporting compliance and configuration management.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "partial": {
+            "description": "Indicates whether the saptune solution is only partially applied, supporting system health and configuration tracking.",
+            "type": "boolean"
+          }
+        },
+        "title": "SaptuneSolution",
+        "type": "object"
+      },
+      "2.5.0_v1_Forbidden": {
+        "additionalProperties": false,
+        "description": "Represents an error response for forbidden access, providing details about the reason the operation could not be performed due to insufficient permissions.",
+        "example": {
+          "errors": [
+            {
+              "detail": "The requested operation could not be performed.",
+              "title": "Forbidden"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
+              {
+                "detail": "The requested operation could not be performed.",
+                "title": "Forbidden"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "description": "Provides a detailed explanation of why the requested operation was forbidden, supporting troubleshooting and resolution.",
+                  "example": "The requested operation could not be performed.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short summary indicating the forbidden status, used for quick identification and error handling.",
+                  "example": "Forbidden",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "Forbidden",
+        "type": "object"
+      },
+      "2.5.0_v1_ErrataDetailsResponse": {
+        "additionalProperties": false,
+        "description": "Represents the response returned from the errata details endpoint, providing details about errata for advisories.",
+        "example": {
+          "affected_packages": [
+            {
+              "arch_label": "x86_64",
+              "epoch": "0",
+              "name": "kernel-default",
+              "release": "1",
+              "version": "5.14.21-150400.24.82.1"
+            }
+          ],
+          "affected_systems": [
+            {
+              "name": "sap-host-01"
+            },
+            {
+              "name": "sap-host-02"
+            }
+          ],
+          "cves": [
+            "CVE-2024-12345",
+            "CVE-2024-12346"
+          ],
+          "errata_details": {
+            "advisory_status": "stable",
+            "description": "This update fixes several security vulnerabilities in the Linux kernel.",
+            "errata_from": "SUSE Security Team",
+            "id": 12345,
+            "issue_date": "2024-01-15",
+            "last_modified_date": "2024-01-15",
+            "notes": "Please reboot after installation",
+            "product": "SUSE Linux Enterprise Server 15 SP4",
+            "reboot_suggested": true,
+            "references": "https://www.suse.com/security/cve/CVE-2024-12345.html",
+            "release": 1,
+            "restart_suggested": false,
+            "solution": "Install the updated packages",
+            "synopsis": "Important security update for kernel",
+            "topic": "Security update",
+            "type": "security",
+            "update_date": "2024-01-15",
+            "vendor_advisory": "SUSE-SU-2024:0001-1"
+          },
+          "fixes": {
+            "bsc#123456": "Fix buffer overflow in network driver",
+            "bsc#123457": "Fix memory leak in filesystem driver"
+          }
+        },
+        "properties": {
+          "affected_packages": {
+            "$ref": "#/components/schemas/2.5.0_v1_AffectedPackages"
+          },
+          "affected_systems": {
+            "$ref": "#/components/schemas/2.5.0_v1_AffectedSystems"
+          },
+          "cves": {
+            "$ref": "#/components/schemas/2.5.0_v1_CVEs"
+          },
+          "errata_details": {
+            "$ref": "#/components/schemas/2.5.0_v1_ErrataDetails"
+          },
+          "fixes": {
+            "$ref": "#/components/schemas/2.5.0_v1_AdvisoryFixes"
+          }
+        },
+        "title": "ErrataDetailsResponse",
+        "type": "object"
+      },
+      "2.5.0_v1_GeneralInformation": {
+        "additionalProperties": false,
+        "description": "General information about the current installation.",
+        "example": {
+          "flavor": "Community",
+          "sles_subscriptions": 5,
+          "version": "2.4.0"
+        },
+        "properties": {
+          "flavor": {
+            "deprecated": true,
+            "description": "Flavor of the current installation.",
+            "enum": [
+              "Community",
+              "Premium"
+            ],
+            "type": "string"
+          },
+          "sles_subscriptions": {
+            "description": "The number of SLES Subscription discovered on the target infrastructure.",
+            "type": "integer"
+          },
+          "version": {
+            "description": "Version of the current server component installation.",
+            "type": "string"
+          }
+        },
+        "title": "GeneralInformation",
+        "type": "object"
+      },
+      "2.5.0_v1_SystemdUnit": {
+        "additionalProperties": false,
+        "description": "Provides information about a systemd service unit, including its name and operational state for system management.",
+        "example": {
+          "name": "sapinit",
+          "unit_file_state": "enabled"
+        },
+        "properties": {
+          "name": {
+            "description": "The name assigned to the systemd unit, used for identification and management.",
+            "type": "string"
+          },
+          "unit_file_state": {
+            "description": "Shows the current state of the systemd unit, such as enabled or disabled, supporting operational management.",
+            "type": "string"
+          }
+        },
+        "title": "SystemdUnit",
+        "type": "object"
+      },
+      "2.5.0_v1_PatchesForPackage": {
+        "additionalProperties": false,
+        "description": "Details the relevant software patches that are included as part of a package upgrade, supporting system maintenance.",
+        "example": {
+          "package_id": 12345,
+          "patches": [
+            {
+              "advisory": "SUSE-SU-2024:0001-1",
+              "advisory_type": "security_advisory",
+              "issue_date": "2024-01-15",
+              "last_modified_date": "2024-01-15",
+              "synopsis": "Critical security update for OpenSSL"
+            }
+          ]
+        },
+        "properties": {
+          "package_id": {
+            "description": "Unique identifier for the package being upgraded, used for tracking and management.",
+            "type": "integer"
+          },
+          "patches": {
+            "additionalProperties": false,
+            "example": [
+              {
+                "advisory": "SUSE-SU-2024:0001-1",
+                "advisory_type": "security_advisory",
+                "issue_date": "2024-01-15",
+                "last_modified_date": "2024-01-15",
+                "synopsis": "Critical security update for OpenSSL"
+              }
+            ],
+            "items": {
+              "additionalProperties": false,
+              "description": "A list containing all relevant software patches that are addressed by the current upgrade, supporting compliance and maintenance.",
+              "properties": {
+                "advisory": {
+                  "description": "The name of the advisory linked to the patch, used for identification and tracking.",
+                  "type": "string"
+                },
+                "advisory_type": {
+                  "description": "Specifies the type of advisory associated with the patch, such as security or bugfix.",
+                  "type": "string"
+                },
+                "issue_date": {
+                  "description": "The date when the advisory was issued, providing historical context for the patch.",
+                  "type": "string"
+                },
+                "last_modified_date": {
+                  "description": "The date when the advisory was last modified, helping track updates and changes over time.",
+                  "type": "string"
+                },
+                "synopsis": {
+                  "description": "A brief summary of the advisory, outlining the main points and impact of the patch.",
+                  "type": "string"
+                }
+              }
+            },
+            "type": "array"
+          }
+        },
+        "title": "PatchesForPackage",
+        "type": "object"
+      },
+      "2.5.0_v1_DatabaseInstance": {
+        "additionalProperties": false,
+        "description": "Represents a discovered HANA Database Instance on the target infrastructure, including its configuration, replication, and operational status.",
+        "example": {
+          "absent_at": "2024-01-15T08:00:00Z",
+          "database_id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+          "features": "HDB|HDB_WORKER",
+          "health": "passing",
+          "host_id": "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+          "http_port": 8000,
+          "https_port": 8443,
+          "inserted_at": "2024-01-15T10:30:00Z",
+          "instance_hostname": "hanadb01",
+          "instance_number": "00",
+          "sap_system_id": "290e8a7b-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+          "sid": "PRD",
+          "start_priority": "0.3",
+          "system_replication": "ENABLED",
+          "system_replication_mode": "ASYNC",
+          "system_replication_operation_mode": "logreplay",
+          "system_replication_site": "Site1",
+          "system_replication_source_site": "Site2",
+          "system_replication_status": "ACTIVE",
+          "system_replication_tier": 1,
+          "tenant": "SYSTEMDB",
+          "updated_at": "2024-01-15T12:45:00Z"
+        },
+        "properties": {
+          "absent_at": {
+            "description": "The timestamp indicating when the database instance became absent, supporting monitoring and troubleshooting.",
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          },
+          "database_id": {
+            "description": "Unique identifier for the database instance, used for tracking and management.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "features": {
+            "description": "Features enabled for the database instance, such as HDB or HDB_WORKER, supporting capability tracking.",
+            "type": "string"
+          },
+          "health": {
+            "$ref": "#/components/schemas/2.5.0_v1_ResourceHealth"
+          },
+          "host_id": {
+            "description": "Unique identifier of the host where the current database instance is running, supporting infrastructure management.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "http_port": {
+            "description": "The HTTP port used by the database instance, supporting connectivity and management.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "https_port": {
+            "description": "The HTTPS port used by the database instance, supporting secure connectivity and management.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "inserted_at": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "instance_hostname": {
+            "description": "The hostname of the server where the database instance is running, supporting infrastructure management.",
+            "nullable": true,
+            "type": "string"
+          },
+          "instance_number": {
+            "description": "The instance number assigned to the database, used for identification and management.",
+            "type": "string"
+          },
+          "sap_system_id": {
+            "deprecated": true,
+            "description": "Unique identifier for the SAP system associated with this database instance, used for tracking and management.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "sid": {
+            "description": "The system identifier (SID) for the database instance, used for SAP system management.",
+            "type": "string"
+          },
+          "start_priority": {
+            "description": "The start priority assigned to the database instance, used for controlling startup order and resource allocation.",
+            "nullable": true,
+            "type": "string"
+          },
+          "system_replication": {
+            "description": "Indicates whether system replication is enabled for the database instance, supporting high availability and disaster recovery.",
+            "type": "string"
+          },
+          "system_replication_mode": {
+            "description": "The mode used for system replication in the database instance, such as SYNC or ASYNC, supporting configuration and management.",
+            "nullable": true,
+            "type": "string"
+          },
+          "system_replication_operation_mode": {
+            "description": "The operation mode for system replication in the database instance, supporting synchronization and failover.",
+            "nullable": true,
+            "type": "string"
+          },
+          "system_replication_site": {
+            "description": "The site associated with system replication for the database instance, supporting multi-site management.",
+            "nullable": true,
+            "type": "string"
+          },
+          "system_replication_source_site": {
+            "description": "The source site from which system replication originates for the database instance, supporting traceability and management.",
+            "nullable": true,
+            "type": "string"
+          },
+          "system_replication_status": {
+            "description": "Shows the current status of system replication for the database instance, supporting monitoring and management.",
+            "type": "string"
+          },
+          "system_replication_tier": {
+            "description": "The tier number of the system replication site for the database instance, supporting hierarchical management.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "tenant": {
+            "description": "The tenant name for the database instance, supporting multi-tenancy and organization.",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "DatabaseInstance",
+        "type": "object"
+      },
+      "2.5.0_v1_Pagination": {
+        "additionalProperties": false,
+        "description": "Metadata describing the pagination state of the current list, including cursors and navigation flags for result sets.",
+        "example": {
+          "end_cursor": "eyJpZCI6IjQ1NmU3ODkwLWE5YmMtMTJkMy1hNDU2LTQyNjYxNDE3NDAwMCJ9",
+          "first": 10,
+          "has_next_page": true,
+          "has_previous_page": false,
+          "last": 5,
+          "start_cursor": "eyJpZCI6IjEyM2U0NTY3LWU4OWItMTJkMy1hNDU2LTQyNjYxNDE3NDAwMCJ9"
+        },
+        "properties": {
+          "end_cursor": {
+            "description": "A cursor value that marks the end of the paginated list, facilitating navigation and result management.",
+            "nullable": true,
+            "type": "string"
+          },
+          "first": {
+            "description": "Number of elements requested from the beginning of the list (forward navigation).",
+            "nullable": true,
+            "type": "integer"
+          },
+          "has_next_page": {
+            "description": "Indicates whether additional pages of results exist beyond the current set, enabling forward navigation.",
+            "nullable": false,
+            "type": "boolean"
+          },
+          "has_previous_page": {
+            "description": "Indicates whether previous pages of results exist before the current set, enabling backward navigation.",
+            "nullable": false,
+            "type": "boolean"
+          },
+          "last": {
+            "description": "Number of elements requested from the end of the list (backward navigation).",
+            "nullable": true,
+            "type": "integer"
+          },
+          "start_cursor": {
+            "description": "A cursor value that marks the beginning of the paginated list, used for efficient navigation and data retrieval.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "start_cursor",
+          "end_cursor",
+          "has_next_page",
+          "has_previous_page",
+          "first",
+          "last"
+        ],
+        "title": "Pagination",
+        "type": "object"
+      },
+      "2.5.0_v1_SAPSystemsCollection": {
+        "description": "A list of discovered SAP systems, each including identification, database, health, and instance details for infrastructure monitoring and management.",
+        "example": [
+          {
+            "application_instances": [],
+            "database_id": "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "database_instances": [],
+            "database_sid": "HA1",
+            "db_host": "10.1.1.5",
+            "ensa_version": "ensa1",
+            "health": "passing",
+            "id": "7269eb74-dd68-4c91-b4d1-4f9d91f2c2c8",
+            "inserted_at": "2024-01-15T10:30:00Z",
+            "sid": "HA1",
+            "tags": [],
+            "tenant": "PRD",
+            "updated_at": "2024-01-15T12:30:00Z"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_SAPSystem"
+        },
+        "title": "SAPSystemsCollection",
+        "type": "array"
+      },
+      "2.5.0_v1_Unauthorized": {
+        "additionalProperties": false,
+        "description": "Error response returned when access to the requested operation is denied due to missing or invalid authentication credentials.",
+        "example": {
+          "errors": [
+            {
+              "detail": "The requested operation could not be authorized.",
+              "title": "Unauthorized"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "description": "A list of error objects describing why access to the requested operation was denied, such as missing or invalid authentication credentials.",
+            "example": [
+              {
+                "detail": "The requested operation could not be authorized.",
+                "title": "Unauthorized"
+              }
+            ],
+            "items": {
+              "description": "Details about a specific error encountered when access is denied, including a human-readable message and error title.",
+              "properties": {
+                "detail": {
+                  "description": "A message describing the reason for the unauthorized access, such as missing or invalid authentication credentials.",
+                  "example": "The requested operation could not be authorized.",
+                  "type": "string"
+                },
+                "title": {
+                  "description": "A short title summarizing the error encountered when access is denied due to authorization failure.",
+                  "example": "Unauthorized",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "Unauthorized",
+        "type": "object"
+      },
+      "2.5.0_v1_SaptuneStatus": {
+        "additionalProperties": false,
+        "description": "Represents the saptune status output on the host, including package version, configuration, tuning state, services, notes, solutions, and staging for system health and compliance.",
+        "example": {
+          "applied_notes": [
+            {
+              "additionally_enabled": false,
+              "id": "1410736"
+            }
+          ],
+          "applied_solution": {
+            "id": "HANA",
+            "partial": false
+          },
+          "configured_version": "3",
+          "enabled_notes": [
+            {
+              "additionally_enabled": false,
+              "id": "1410736"
+            }
+          ],
+          "enabled_solution": {
+            "id": "HANA",
+            "partial": false
+          },
+          "package_version": "3.1.0",
+          "services": [
+            {
+              "active": "active",
+              "enabled": "enabled",
+              "name": "saptune"
+            }
+          ],
+          "staging": {
+            "enabled": true,
+            "notes": [
+              "1410736"
+            ],
+            "solutions_ids": [
+              "HANA"
+            ]
+          },
+          "tuning_state": "applied"
+        },
+        "nullable": true,
+        "properties": {
+          "applied_notes": {
+            "description": "A list of saptune notes that have been applied on the host, supporting compliance and configuration tracking.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_SaptuneNote"
+            },
+            "type": "array"
+          },
+          "applied_solution": {
+            "$ref": "#/components/schemas/2.5.0_v1_SaptuneSolution"
+          },
+          "configured_version": {
+            "description": "The version of saptune configuration applied on the host, supporting system health and compliance tracking.",
+            "type": "string"
+          },
+          "enabled_notes": {
+            "description": "A list of saptune notes that are currently enabled on the host, supporting compliance and configuration tracking.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_SaptuneNote"
+            },
+            "type": "array"
+          },
+          "enabled_solution": {
+            "$ref": "#/components/schemas/2.5.0_v1_SaptuneSolution"
+          },
+          "package_version": {
+            "description": "The version of the saptune package installed on the host, supporting system health and compliance tracking.",
+            "type": "string"
+          },
+          "services": {
+            "description": "A list of saptune services running on the host, supporting system health and configuration management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v1_SaptuneService"
+            },
+            "type": "array"
+          },
+          "staging": {
+            "$ref": "#/components/schemas/2.5.0_v1_SaptuneStaging"
+          },
+          "tuning_state": {
+            "description": "The current tuning state of saptune on the host, supporting system health and configuration tracking.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "package_version"
+        ],
+        "title": "SaptuneStatus",
+        "type": "object"
+      },
+      "2.5.0_v1_ClusterResource": {
+        "additionalProperties": false,
+        "description": "Represents a resource within a cluster, including its type, role, and operational status for management and monitoring.",
+        "example": {
+          "fail_count": 0,
+          "id": "msl_SAPHana_PRD_HDB00",
+          "role": "Master",
+          "status": "Started",
+          "type": "ocf::suse:SAPHanaTopology"
+        },
+        "properties": {
+          "fail_count": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "title": "ClusterResource",
+        "type": "object"
+      },
+      "2.5.0_v1_SaveSuseManagerSettingsRequest": {
+        "additionalProperties": false,
+        "description": "Represents the request body for saving SUSE Manager (SUMA) settings, including connection and authentication details for secure management.",
+        "example": {
+          "ca_cert": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV\n...\n-----END CERTIFICATE-----",
+          "password": "secretpassword",
+          "url": "https://suse-manager.example.com",
+          "username": "admin"
+        },
+        "properties": {
+          "ca_cert": {
+            "example": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKoK/heBjcOuMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV\n...\n-----END CERTIFICATE-----",
+            "type": "string"
+          },
+          "password": {
+            "example": "secretpassword",
+            "type": "string"
+          },
+          "url": {
+            "example": "https://suse-manager.example.com",
+            "type": "string"
+          },
+          "username": {
+            "example": "admin",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "username",
+          "password"
+        ],
+        "title": "SaveSuseManagerSettingsRequest",
+        "type": "object"
+      },
+      "2.5.0_v1_HttpSTDTargetList": {
+        "description": "A list containing all HTTP service discovery targets, supporting network monitoring and management.",
+        "example": [
+          {
+            "labels": {
+              "environment": "production",
+              "service": "web"
+            },
+            "targets": [
+              "myhost.de",
+              "10.1.1.5"
+            ]
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v1_HttpStd"
+        },
+        "title": "HttpSTDTargetList",
+        "type": "array"
+      },
+      "2.5.0_v2_AscsErsClusterDetails": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing the details of an ASCS/ERS Pacemaker cluster, including fencing, maintenance, managed SAP systems, devices, stopped resources, and resources for infrastructure monitoring and management.",
+        "example": {
+          "fencing_type": "external/sbd",
+          "maintenance_mode": false,
+          "resources": [
+            {
+              "fail_count": 0,
+              "id": "rsc_SAPInstance_HA1_ASCS00",
+              "role": "Started",
+              "status": "Started",
+              "type": "ocf::heartbeat:SAPInstance"
+            }
+          ],
+          "sap_systems": [
+            {
+              "distributed": false,
+              "filesystem_resource_based": true,
+              "nodes": [
+                {
+                  "filesystems": [
+                    "/sapmnt/HA1",
+                    "/usr/sap/HA1/ASCS00"
+                  ],
+                  "name": "node01",
+                  "roles": [
+                    "ascs"
+                  ],
+                  "virtual_ips": [
+                    "192.168.1.10"
+                  ]
+                }
+              ],
+              "sid": "HA1"
+            }
+          ],
+          "sbd_devices": [
+            {
+              "device": "/dev/disk/by-id/scsi-SLIO-ORG_disk_01",
+              "status": "healthy"
+            }
+          ],
+          "stopped_resources": []
+        },
+        "properties": {
+          "fencing_type": {
+            "description": "The fencing type used in the ASCS/ERS cluster, supporting infrastructure protection and management.",
+            "type": "string"
+          },
+          "maintenance_mode": {
+            "description": "Indicates whether maintenance mode is enabled for the ASCS/ERS cluster, supporting infrastructure management and troubleshooting.",
+            "type": "boolean"
+          },
+          "resources": {
+            "description": "A list of cluster resources associated with this ASCS/ERS cluster, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_ClusterResource"
+            }
+          },
+          "sap_systems": {
+            "description": "A list of managed SAP systems in a single or multi SID ASCS/ERS cluster, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_AscsErsClusterSAPSystem"
+            },
+            "type": "array"
+          },
+          "sbd_devices": {
+            "description": "A list of SBD devices used in the ASCS/ERS cluster, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_SbdDevice"
+            },
+            "type": "array"
+          },
+          "stopped_resources": {
+            "deprecated": true,
+            "description": "A list of the stopped resources on this ASCS/ERS cluster, supporting infrastructure monitoring and management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_ClusterResource"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sap_systems"
+        ],
+        "title": "AscsErsClusterDetails",
+        "type": "object"
+      },
+      "2.5.0_v2_AscsErsClusterNode": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing an ASCS/ERS cluster node, including name, status, attributes, filesystems, roles, virtual IPs, and resources for infrastructure monitoring and management.",
+        "example": {
+          "attributes": {
+            "ascs_group": "grp_HA1_ASCS00"
+          },
+          "filesystems": [
+            "/sapmnt/HA1",
+            "/usr/sap/HA1/ASCS00"
+          ],
+          "name": "node01",
+          "resources": [
+            {
+              "fail_count": 0,
+              "id": "rsc_SAPInstance_HA1_ASCS00",
+              "role": "Started",
+              "status": "Started",
+              "type": "ocf::heartbeat:SAPInstance"
+            }
+          ],
+          "roles": [
+            "ascs"
+          ],
+          "status": "online",
+          "virtual_ips": [
+            "192.168.1.10"
+          ]
+        },
+        "properties": {
+          "attributes": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "A set of attributes describing the configuration and state of the ASCS/ERS cluster node, supporting monitoring and management.",
+            "type": "object"
+          },
+          "filesystems": {
+            "description": "A list of filesystems managed in this ASCS/ERS cluster node, supporting infrastructure management.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "The name of the ASCS/ERS cluster node, supporting identification and management.",
+            "type": "string"
+          },
+          "resources": {
+            "deprecated": true,
+            "description": "A list of cluster resources associated with this ASCS/ERS cluster node, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_ClusterResource"
+            },
+            "type": "array"
+          },
+          "roles": {
+            "description": "A list of roles managed in this ASCS/ERS cluster node, supporting infrastructure management.",
+            "items": {
+              "enum": [
+                "ascs",
+                "ers"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "description": "The operational status of the ASCS/ERS cluster node, supporting monitoring and alerting.",
+            "type": "string"
+          },
+          "virtual_ips": {
+            "description": "A list of virtual IPs managed in this ASCS/ERS cluster node, supporting infrastructure management.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "title": "AscsErsClusterNode",
+        "type": "object"
+      },
+      "2.5.0_v2_AscsErsClusterSAPSystem": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing an SAP system managed by an ASCS/ERS cluster, including SID, distribution, filesystems, and nodes for infrastructure monitoring and management.",
+        "example": {
+          "distributed": false,
+          "filesystem_resource_based": true,
+          "nodes": [
+            {
+              "filesystems": [
+                "/sapmnt/HA1",
+                "/usr/sap/HA1/ASCS00"
+              ],
+              "name": "node01",
+              "roles": [
+                "ascs"
+              ],
+              "virtual_ips": [
+                "192.168.1.10"
+              ]
+            }
+          ],
+          "sid": "HA1"
+        },
+        "properties": {
+          "distributed": {
+            "description": "Indicates whether ASCS and ERS instances are distributed and running in different nodes, supporting infrastructure management.",
+            "type": "boolean"
+          },
+          "filesystem_resource_based": {
+            "description": "Indicates whether ASCS and ERS filesystems are handled by the cluster with the Filesystem resource agent, supporting infrastructure management.",
+            "type": "boolean"
+          },
+          "nodes": {
+            "description": "A list of ASCS/ERS nodes for this SAP system, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_AscsErsClusterNode"
+            },
+            "type": "array"
+          },
+          "sid": {
+            "description": "The SAP system identifier (SID) managed by the ASCS/ERS cluster, supporting system identification.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sid"
+        ],
+        "title": "AscsErsClusterSAPSystem",
+        "type": "object"
+      },
+      "2.5.0_v2_ClusterResource": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing a cluster resource, including identification, type, role, status, and parent information for infrastructure management.",
+        "example": {
+          "fail_count": 0,
+          "id": "ocf:heartbeat:IPaddr2",
+          "managed": true,
+          "node": "node-01",
+          "parent": {
+            "id": "cluster-ip-group",
+            "managed": true,
+            "multi_state": false
+          },
+          "role": "Started",
+          "status": "running",
+          "type": "ocf"
+        },
+        "properties": {
+          "fail_count": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "managed": {
+            "type": "boolean"
+          },
+          "node": {
+            "nullable": true,
+            "type": "string"
+          },
+          "parent": {
+            "additionalProperties": false,
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "managed": {
+                "description": "Indicates whether the resource is managed by the cluster infrastructure, supporting automated management and monitoring.",
+                "type": "boolean"
+              },
+              "multi_state": {
+                "description": "Represents the type of the group.\r\n- true: promotable group\r\n- false: cloned group\r\n- null: standard group\r\n",
+                "nullable": true,
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "role": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "title": "ClusterResource",
+        "type": "object"
+      },
+      "2.5.0_v2_HanaClusterDetails": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing the details of a HANA Pacemaker cluster, including architecture, scenario, replication, health, nodes, sites, devices, and resources for infrastructure monitoring and management.",
+        "example": {
+          "architecture_type": "classic",
+          "fencing_type": "external/sbd",
+          "hana_scenario": "performance_optimized",
+          "maintenance_mode": false,
+          "nodes": [
+            {
+              "attributes": {
+                "hana_prd_op_mode": "logreplay"
+              },
+              "hana_status": "Primary",
+              "name": "hana01",
+              "site": "NUREMBERG"
+            }
+          ],
+          "resources": [
+            {
+              "fail_count": 0,
+              "id": "rsc_SAPHana_PRD_HDB00",
+              "role": "Master",
+              "status": "running",
+              "type": "ocf::suse:SAPHana"
+            }
+          ],
+          "sbd_devices": [
+            {
+              "device": "/dev/disk/by-id/scsi-SLIO-ORG_disk_01",
+              "status": "healthy"
+            }
+          ],
+          "secondary_sync_state": "SOK",
+          "sites": [
+            {
+              "name": "NUREMBERG",
+              "sr_health_state": "4",
+              "state": "Primary"
+            }
+          ],
+          "sr_health_state": "4",
+          "stopped_resources": [],
+          "system_replication_mode": "sync",
+          "system_replication_operation_mode": "logreplay"
+        },
+        "properties": {
+          "architecture_type": {
+            "description": "The architecture type of the HANA cluster, supporting infrastructure classification and management.",
+            "enum": [
+              "classic",
+              "angi"
+            ],
+            "type": "string"
+          },
+          "fencing_type": {
+            "description": "The fencing type used in the HANA cluster, supporting infrastructure protection and management.",
+            "type": "string"
+          },
+          "hana_scenario": {
+            "description": "The scenario type of the HANA cluster, supporting infrastructure classification and management.",
+            "enum": [
+              "cost_optimized",
+              "performance_optimized",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "maintenance_mode": {
+            "description": "Indicates whether maintenance mode is enabled for the HANA cluster, supporting infrastructure management and troubleshooting.",
+            "type": "boolean"
+          },
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_HanaClusterNode"
+            },
+            "type": "array"
+          },
+          "resources": {
+            "description": "A list of cluster resources associated with this HANA cluster, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_ClusterResource"
+            }
+          },
+          "sbd_devices": {
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_SbdDevice"
+            },
+            "type": "array"
+          },
+          "secondary_sync_state": {
+            "description": "The secondary sync state of the HANA cluster, supporting data protection and availability.",
+            "type": "string"
+          },
+          "sites": {
+            "description": "A list of HANA cluster sites, supporting infrastructure monitoring and management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_HanaClusterSite"
+            },
+            "type": "array"
+          },
+          "sr_health_state": {
+            "deprecated": true,
+            "description": "The system replication health state of the HANA cluster, supporting infrastructure health tracking.",
+            "type": "string"
+          },
+          "stopped_resources": {
+            "deprecated": true,
+            "description": "A list of the stopped resources on this HANA cluster, supporting infrastructure monitoring and management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_ClusterResource"
+            },
+            "type": "array"
+          },
+          "system_replication_mode": {
+            "description": "The system replication mode of the HANA cluster, supporting data protection and availability.",
+            "type": "string"
+          },
+          "system_replication_operation_mode": {
+            "description": "The system replication operation mode of the HANA cluster, supporting data protection and availability.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "nodes"
+        ],
+        "title": "HanaClusterDetails",
+        "type": "object"
+      },
+      "2.5.0_v2_HanaClusterNode": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing a HANA cluster node, including name, site, roles, status, attributes, and resources for infrastructure monitoring and management.",
+        "example": {
+          "attributes": {
+            "hana_prd_op_mode": "logreplay",
+            "hana_prd_srmode": "sync"
+          },
+          "hana_status": "Primary",
+          "indexserver_actual_role": "master",
+          "name": "hana01",
+          "nameserver_actual_role": "master",
+          "resources": [
+            {
+              "fail_count": 0,
+              "id": "rsc_SAPHana_PRD_HDB00",
+              "role": "Master",
+              "status": "running",
+              "type": "ocf::suse:SAPHana"
+            }
+          ],
+          "site": "NUREMBERG",
+          "status": "online",
+          "virtual_ip": "192.168.1.10"
+        },
+        "properties": {
+          "attributes": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "A set of attributes describing the configuration and state of the HANA cluster node, supporting monitoring and management.",
+            "type": "object"
+          },
+          "hana_status": {
+            "deprecated": true,
+            "type": "string"
+          },
+          "indexserver_actual_role": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameserver_actual_role": {
+            "nullable": true,
+            "type": "string"
+          },
+          "resources": {
+            "deprecated": true,
+            "description": "A list of cluster resources associated with this HANA cluster node, supporting infrastructure management.",
+            "items": {
+              "$ref": "#/components/schemas/2.5.0_v2_ClusterResource"
+            },
+            "type": "array"
+          },
+          "site": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "virtual_ip": {
+            "type": "string"
+          }
+        },
+        "title": "HanaClusterNode",
+        "type": "object"
+      },
+      "2.5.0_v2_HanaClusterSite": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing a HANA cluster site, including name, state, and system replication health state for infrastructure monitoring and management.",
+        "example": {
+          "name": "NUREMBERG",
+          "sr_health_state": "4",
+          "state": "Primary"
+        },
+        "properties": {
+          "name": {
+            "description": "The name of the HANA cluster site, supporting identification and management.",
+            "type": "string"
+          },
+          "sr_health_state": {
+            "description": "The system replication health state of the HANA cluster site, supporting infrastructure health tracking.",
+            "type": "string"
+          },
+          "state": {
+            "description": "The operational state of the HANA cluster site, supporting monitoring and alerting.",
+            "type": "string"
+          }
+        },
+        "title": "HanaClusterSite",
+        "type": "object"
+      },
+      "2.5.0_v2_PacemakerCluster": {
+        "additionalProperties": false,
+        "description": "A comprehensive object representing a discovered Pacemaker cluster on the target infrastructure, including identification, type, provider, health, resources, hosts, details, and tags for infrastructure monitoring and management.",
+        "example": {
+          "additional_sids": [
+            "ASCS"
+          ],
+          "cib_last_written": "2024-01-15T10:30:00Z",
+          "details": {
+            "nodes": [],
+            "secondary_sync_state": "SOK",
+            "system_replication_mode": "sync",
+            "system_replication_operation_mode": "logreplay"
+          },
+          "health": "passing",
+          "hosts_number": 2,
+          "id": "123e4567-e89b-12d3-a456-426614174000",
+          "inserted_at": "2024-01-15T09:00:00Z",
+          "name": "hana_cluster",
+          "provider": "azure",
+          "resources_number": 10,
+          "sap_instances": [
+            {
+              "instance_number": "00",
+              "sid": "PRD"
+            }
+          ],
+          "selected_checks": [
+            "check_2"
+          ],
+          "sid": "PRD",
+          "tags": [
+            {
+              "resource_id": "123e4567-e89b-12d3-a456-426614174000",
+              "resource_type": "cluster",
+              "value": "production"
+            }
+          ],
+          "type": "hana_scale_up",
+          "updated_at": "2024-01-15T10:30:00Z"
+        },
+        "properties": {
+          "additional_sids": {
+            "deprecated": true,
+            "description": "A list of additionally discovered SIDs, such as ASCS/ERS cluster SIDs. Deprecated: use sap_instances instead.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "cib_last_written": {
+            "description": "The date and time when the CIB was last written for the Pacemaker cluster, supporting audit and monitoring.",
+            "nullable": true,
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/components/schemas/2.5.0_v2_PacemakerClusterDetails"
+          },
+          "health": {
+            "$ref": "#/components/schemas/2.5.0_v2_ResourceHealth"
+          },
+          "hosts_number": {
+            "description": "The number of hosts in the Pacemaker cluster, supporting infrastructure monitoring and management.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "id": {
+            "description": "Cluster ID.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inserted_at": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the Pacemaker cluster, supporting identification and management.",
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/2.5.0_v2_SupportedProviders"
+          },
+          "resources_number": {
+            "description": "The number of resources in the Pacemaker cluster, supporting infrastructure monitoring and management.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "sap_instances": {
+            "description": "A list of SAP instances in the Pacemaker cluster, including their SID and additional information for infrastructure management.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "instance_number": {
+                  "description": "The SAP instance number in the Pacemaker cluster, supporting system identification.",
+                  "type": "string"
+                },
+                "sid": {
+                  "description": "The SAP instance identifier (SID) in the Pacemaker cluster, supporting system identification.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "sid",
+                "instance_number"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "selected_checks": {
+            "description": "A list of check IDs selected for an execution on this Pacemaker cluster, supporting monitoring and management.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sid": {
+            "deprecated": true,
+            "description": "The SAP system identifier (SID) for the Pacemaker cluster. Deprecated: use sap_instances instead.",
+            "type": "string"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/2.5.0_v2_Tags"
+          },
+          "type": {
+            "description": "The detected type of the Pacemaker cluster, supporting infrastructure classification and management.",
+            "enum": [
+              "hana_scale_up",
+              "hana_scale_out",
+              "ascs_ers",
+              "hana_ascs_ers",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "title": "PacemakerCluster",
+        "type": "object"
+      },
+      "2.5.0_v2_PacemakerClusterDetails": {
+        "description": "A comprehensive object representing the details of the detected Pacemaker cluster, including ASCS/ERS and HANA cluster details for infrastructure monitoring and management.",
+        "example": {
+          "nodes": [
+            {
+              "hana_status": "Primary",
+              "name": "hana01",
+              "site": "NUREMBERG"
+            }
+          ],
+          "secondary_sync_state": "SOK",
+          "system_replication_mode": "sync",
+          "system_replication_operation_mode": "logreplay"
+        },
+        "nullable": true,
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/2.5.0_v2_AscsErsClusterDetails"
+          },
+          {
+            "$ref": "#/components/schemas/2.5.0_v2_HanaClusterDetails"
+          }
+        ],
+        "title": "PacemakerClusterDetails",
+        "type": "object"
+      },
+      "2.5.0_v2_PacemakerClustersCollection": {
+        "description": "A comprehensive array representing a list of discovered Pacemaker clusters, each including identification, type, provider, health, resources, hosts, details, and tags for infrastructure monitoring and management.",
+        "example": [
+          {
+            "additional_sids": [
+              "ERS",
+              "ASCS"
+            ],
+            "cib_last_written": "2024-01-15T10:30:00Z",
+            "health": "passing",
+            "hosts_number": 2,
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "inserted_at": "2024-01-15T09:00:00Z",
+            "name": "hana_cluster",
+            "provider": "azure",
+            "resources_number": 10,
+            "selected_checks": [
+              "check_1",
+              "check_2"
+            ],
+            "sid": "PRD",
+            "type": "hana_scale_up",
+            "updated_at": "2024-01-15T10:30:00Z"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v2_PacemakerCluster"
+        },
+        "title": "PacemakerClustersCollection",
+        "type": "array"
+      },
+      "2.5.0_v2_ResourceHealth": {
+        "description": "Represents the detected health status of a resource, indicating whether it is passing, critical, or unknown for monitoring and alerting purposes.",
+        "enum": [
+          "passing",
+          "warning",
+          "critical",
+          "unknown"
+        ],
+        "example": "passing",
+        "nullable": true,
+        "title": "ResourceHealth",
+        "type": "string"
+      },
+      "2.5.0_v2_SbdDevice": {
+        "additionalProperties": false,
+        "description": "Represents a SBD device used for fencing and high availability in cluster environments.",
+        "example": {
+          "device": "/dev/disk/by-id/scsi-SLIO-ORG_disk_01",
+          "status": "healthy"
+        },
+        "properties": {
+          "device": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "title": "SbdDevice",
+        "type": "object"
+      },
+      "2.5.0_v2_SupportedProviders": {
+        "description": "Indicates the cloud provider detected for the resource, such as Azure, AWS, or GCP, supporting infrastructure identification.",
+        "enum": [
+          "azure",
+          "aws",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "vmware",
+          "unknown"
+        ],
+        "example": "azure",
+        "title": "SupportedProviders",
+        "type": "string"
+      },
+      "2.5.0_v2_Tag": {
+        "additionalProperties": false,
+        "description": "Represents a tag attached to a resource, including its identifier, type, value, and timestamps for resource classification and management.",
+        "example": {
+          "id": 1,
+          "inserted_at": "2024-01-15T09:00:00Z",
+          "resource_id": "123e4567-e89b-12d3-a456-426614174000",
+          "resource_type": "host",
+          "updated_at": "2024-01-15T10:30:00Z",
+          "value": "production"
+        },
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "inserted_at": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "resource_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "resource_type": {
+            "enum": [
+              "host",
+              "cluster",
+              "sap_system",
+              "database"
+            ],
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "datetime",
+            "nullable": true,
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "title": "Tag",
+        "type": "object"
+      },
+      "2.5.0_v2_Tags": {
+        "description": "A list of tags attached to a resource, supporting resource classification, filtering, and management across the infrastructure.",
+        "example": [
+          {
+            "id": 1,
+            "inserted_at": "2024-01-15T09:00:00Z",
+            "resource_id": "123e4567-e89b-12d3-a456-426614174000",
+            "resource_type": "host",
+            "updated_at": "2024-01-15T10:30:00Z",
+            "value": "production"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/2.5.0_v2_Tag"
+        },
+        "title": "Tags",
+        "type": "array"
+      },
+      "1.5.0_v1_AcceptedExecutionResponse": {
+        "additionalProperties": false,
+        "description": "This response contains the identifiers for an execution that was recently accepted by the system. These identifiers can be used to query the execution status later.",
+        "example": {
+          "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+          "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79"
+        },
+        "properties": {
+          "execution_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "group_id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "title": "AcceptedExecutionResponse",
+        "type": "object"
+      },
+      "1.5.0_v1_AgentCheckError": {
+        "additionalProperties": false,
+        "description": "Indicates that some facts could not be gathered on a specific agent due to issues such as gathering failure or timeout. This error provides context for troubleshooting agent data collection problems.",
+        "example": {
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "facts": [
+            {
+              "check_id": "SLES-HA-1",
+              "name": "node_count",
+              "value": 3
+            },
+            {
+              "check_id": "SLES-HA-1",
+              "message": "Timeout",
+              "name": "node_count",
+              "type": "gathering_error"
+            }
+          ],
+          "message": "Timeout while gathering facts",
+          "type": "gathering_error"
+        },
+        "properties": {
+          "agent_id": {
+            "description": "The unique identifier of the agent involved in the error.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "facts": {
+            "description": "Facts gathered from the target agent, which may include errors encountered during the data collection process.",
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/AgentCheckResult"
+                  "$ref": "#/components/schemas/1.5.0_v1_Fact"
                 },
                 {
-                  "$ref": "#/components/schemas/AgentCheckError"
+                  "$ref": "#/components/schemas/1.5.0_v1_FactError"
                 }
-              ],
-              "x-struct": null,
-              "x-validate": null
+              ]
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "nullable": true,
+            "type": "array"
           },
-          "check_id": {
-            "description": "Check ID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "message": {
+            "description": "A detailed message describing the error encountered during fact gathering on the agent.",
+            "type": "string"
           },
-          "customized": {
-            "description": "Whether the check has been customized",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "expectation_results": {
-            "items": {
-              "$ref": "#/components/schemas/ExpectationResult"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "result": {
-            "description": "Result of the check",
-            "enum": ["passing", "warning", "critical"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "type": {
+            "description": "The type of error encountered during fact gathering on the agent.",
+            "type": "string"
           }
         },
         "required": [
-          "check_id",
-          "expectation_results",
-          "agents_check_results",
-          "result"
+          "agent_id",
+          "type",
+          "message"
         ],
-        "title": "CheckResult",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "title": "AgentCheckError",
+        "type": "object"
       },
-      "ExecutionResponse": {
-        "additionalProperties": false,
-        "description": "The representation of an execution, it may be a running or completed one",
-        "properties": {
-          "check_results": {
-            "items": {
-              "$ref": "#/components/schemas/CheckResult"
-            },
-            "nullable": true,
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "completed_at": {
-            "description": "Execution completion time",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "critical_count": {
-            "description": "Number of checks with critical result",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "execution_id": {
-            "description": "Execution ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "group_id": {
-            "description": "Group ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "passing_count": {
-            "description": "Number of checks with passing result",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "result": {
-            "description": "Aggregated result of the execution, unknown for running ones",
-            "enum": ["passing", "warning", "critical"],
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "started_at": {
-            "description": "Execution start time",
-            "format": "date-time",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "status": {
-            "description": "The status of the current execution",
-            "enum": ["running", "completed"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "targets": {
-            "items": {
-              "$ref": "#/components/schemas/Target"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "timeout": {
-            "description": "Timed out agents",
-            "items": {
-              "description": "Agent ID",
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "nullable": true,
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "warning_count": {
-            "description": "Number of checks with warning result",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          }
+      "1.5.0_v1_AgentCheckResult": {
+        "description": "Represents the result of a check performed on a specific agent, including gathered facts and expectation evaluations.",
+        "example": {
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "expectation_evaluations": [
+            {
+              "name": "fencing_enabled",
+              "return_value": true,
+              "type": "expect"
+            }
+          ],
+          "facts": [
+            {
+              "check_id": "SLES-HA-1",
+              "name": "node_count",
+              "value": 3
+            }
+          ],
+          "values": [
+            {
+              "check_id": "SLES-HA-1",
+              "customized": false,
+              "name": "fencing_configured",
+              "value": true
+            }
+          ]
         },
-        "required": [
-          "execution_id",
-          "group_id",
-          "status",
-          "started_at",
-          "completed_at",
-          "result",
-          "targets",
-          "critical_count",
-          "warning_count",
-          "passing_count",
-          "timeout",
-          "check_results"
-        ],
-        "title": "ExecutionResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "CustomizationResponse": {
-        "additionalProperties": false,
-        "description": "Response for a customization",
         "properties": {
+          "agent_id": {
+            "description": "The unique identifier of the agent for which the check was performed.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "expectation_evaluations": {
+            "description": "Result of the single expectation evaluation, indicating whether the expectation was met for the agent's check.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/1.5.0_v1_ExpectationEvaluation"
+                },
+                {
+                  "$ref": "#/components/schemas/1.5.0_v1_ExpectationEvaluationError"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "facts": {
+            "description": "Facts gathered from the target agent during the check execution.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_Fact"
+            },
+            "type": "array"
+          },
           "values": {
-            "description": "List of the custom values applied",
+            "description": "Values resolved for the current execution, representing the computed results for the agent's check.",
             "items": {
-              "$ref": "#/components/schemas/CustomValue"
+              "$ref": "#/components/schemas/1.5.0_v1_Value"
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           }
         },
-        "title": "CustomizationResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "required": [
+          "agent_id",
+          "facts",
+          "expectation_evaluations"
+        ],
+        "title": "AgentCheckResult",
+        "type": "object"
       },
-      "NotCustomizedCheckValue": {
+      "1.5.0_v1_AgentReport": {
         "additionalProperties": false,
-        "description": "A check value that is not customized",
-        "properties": {
-          "customizable": {
-            "description": "Whether the check is customizable or not",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
+        "description": "Represents an individual agent report of an operation, including agent identification, result, state differences, and error messages.",
+        "example": {
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "diff": {
+            "after": "present",
+            "before": "absent"
           },
-          "default_value": {
-            "description": "Original value as defined by specification. Resolved based on the environment. Absent if value is not customizable.",
-            "oneOf": [
-              {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
+          "error_message": "",
+          "result": "updated"
+        },
+        "properties": {
+          "agent_id": {
+            "description": "The unique identifier of the agent for which the report is generated.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "diff": {
+            "additionalProperties": false,
+            "description": "The difference in the agent's state before and after the operation, useful for tracking changes.",
+            "nullable": true,
+            "properties": {
+              "after": {
+                "description": "The state of the agent after applying the operation, showing the result of the change."
               },
+              "before": {
+                "description": "The state of the agent before applying the operation, providing context for the change."
+              }
+            },
+            "required": [
+              "before",
+              "after"
+            ],
+            "type": "object"
+          },
+          "error_message": {
+            "description": "A detailed error message in case the operation failed for the agent, providing troubleshooting information.",
+            "nullable": true,
+            "type": "string"
+          },
+          "result": {
+            "enum": [
+              "updated",
+              "not_updated",
+              "failed",
+              "rolled_back",
+              "timeout",
+              "skipped",
+              "not_executed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_id",
+          "result",
+          "diff",
+          "error_message"
+        ],
+        "title": "AgentReport",
+        "type": "object"
+      },
+      "1.5.0_v1_BadRequest": {
+        "additionalProperties": false,
+        "description": "This response indicates that the request was malformed or contained invalid parameters, and could not be processed.",
+        "example": {
+          "errors": [
+            {
+              "detail": "Invalid request payload.",
+              "title": "Bad Request"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
               {
-                "anyOf": [
-                  {
-                    "type": "integer",
-                    "x-struct": null,
-                    "x-validate": null
-                  },
-                  {
-                    "type": "number",
-                    "x-struct": null,
-                    "x-validate": null
-                  }
-                ],
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "boolean",
-                "x-struct": null,
-                "x-validate": null
+                "detail": "Invalid request payload.",
+                "title": "Bad Request"
               }
             ],
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Value name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "items": {
+              "properties": {
+                "detail": {
+                  "example": "Invalid request payload.",
+                  "type": "string"
+                },
+                "title": {
+                  "example": "Bad Request",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
           }
         },
-        "required": ["name", "customizable"],
-        "title": "NotCustomizedCheckValue",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "title": "BadRequest",
+        "type": "object"
       },
-      "Check": {
+      "1.5.0_v1_CatalogResponse": {
         "additionalProperties": false,
-        "description": "A single check from the catalog",
+        "description": "Represents the response for a catalog listing, including a list of catalog checks and their details.",
+        "example": {
+          "items": [
+            {
+              "description": "Verifies whether fencing is configured for all nodes in the cluster to ensure high availability, providing context for remediation.",
+              "expectations": [
+                {
+                  "expression": "fencing_configured == true",
+                  "failure_message": "Fencing is not configured for all nodes.",
+                  "name": "fencing_enabled",
+                  "type": "expect"
+                }
+              ],
+              "facts": [
+                {
+                  "argument": "",
+                  "gatherer": "cluster_node_gatherer",
+                  "name": "node_count"
+                }
+              ],
+              "group": "SLES-HA",
+              "id": "SLES-HA-1",
+              "metadata": {
+                "category": "ha",
+                "impact": "critical"
+              },
+              "name": "Cluster node fencing configured",
+              "premium": false,
+              "remediation": "Configure fencing for all cluster nodes to ensure high availability.",
+              "severity": "critical",
+              "values": [
+                {
+                  "conditions": [
+                    {
+                      "expression": "node_count > 1",
+                      "value": true
+                    }
+                  ],
+                  "default": false,
+                  "name": "fencing_configured"
+                }
+              ],
+              "when": "node_count > 0"
+            }
+          ]
+        },
+        "properties": {
+          "items": {
+            "description": "A list of catalog checks included in the response, each with metadata and configuration options.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_Check"
+            },
+            "type": "array"
+          }
+        },
+        "title": "CatalogResponse",
+        "type": "object"
+      },
+      "1.5.0_v1_Check": {
+        "additionalProperties": false,
+        "description": "Represents a single check from the catalog, including its metadata, configuration, and validation logic.",
+        "example": {
+          "description": "Checks if fencing is configured for all cluster nodes.",
+          "expectations": [
+            {
+              "expression": "fencing_configured == true",
+              "failure_message": "Fencing is not configured for all nodes.",
+              "name": "fencing_enabled",
+              "type": "expect"
+            }
+          ],
+          "facts": [
+            {
+              "argument": "",
+              "gatherer": "cluster_node_gatherer",
+              "name": "node_count"
+            }
+          ],
+          "group": "SLES-HA",
+          "id": "SLES-HA-1",
+          "metadata": {
+            "category": "ha",
+            "impact": "critical"
+          },
+          "name": "Cluster node fencing configured",
+          "premium": false,
+          "remediation": "Configure fencing for all cluster nodes to ensure high availability.",
+          "severity": "critical",
+          "values": [
+            {
+              "conditions": [
+                {
+                  "expression": "node_count > 1",
+                  "value": true
+                }
+              ],
+              "default": false,
+              "name": "fencing_configured"
+            }
+          ],
+          "when": "node_count > 0"
+        },
         "properties": {
           "description": {
-            "description": "Check description",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "A description of the check, outlining its purpose and expected behavior.",
+            "type": "string"
           },
           "expectations": {
             "items": {
               "additionalProperties": false,
               "properties": {
                 "expression": {
-                  "description": "Expression to be evaluated to get the expectation result",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "The expression to be evaluated to get the expectation result for the check.",
+                  "type": "string"
                 },
                 "failure_message": {
-                  "description": "Message returned when the check fails",
+                  "description": "A message returned when the check fails, providing context for troubleshooting.",
                   "nullable": true,
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "type": "string"
                 },
                 "name": {
-                  "description": "Expectation name",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "The name of the expectation for the check.",
+                  "type": "string"
                 },
                 "type": {
-                  "description": "Expectation type",
-                  "enum": ["unknown", "expect", "expect_same"],
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "The type of expectation for the check, such as expect or expect_same.",
+                  "enum": [
+                    "unknown",
+                    "expect",
+                    "expect_same"
+                  ],
+                  "type": "string"
                 }
               },
-              "required": ["name", "type", "expression", "failure_message"],
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
+              "required": [
+                "name",
+                "type",
+                "expression",
+                "failure_message"
+              ],
+              "type": "object"
             },
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           },
           "facts": {
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "argument": {
+                  "description": "The argument provided to the gatherer for fact collection.",
+                  "type": "string"
+                },
+                "gatherer": {
+                  "description": "The gatherer used to collect the fact for the check.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the fact gathered for the check.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "gatherer",
+                "argument"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
           "group": {
-            "description": "Check group",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "The group to which the check belongs, providing logical organization.",
+            "type": "string"
           },
           "id": {
-            "description": "Check ID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "The unique identifier of the check in the catalog.",
+            "type": "string"
           },
           "metadata": {
-            "description": "Check metadata",
+            "description": "Metadata associated with the check, providing additional context and categorization.",
             "nullable": true,
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
+            "type": "object"
           },
           "name": {
-            "description": "Check name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "The name of the check in the catalog, used for identification and reporting.",
+            "type": "string"
           },
           "premium": {
             "deprecated": true,
             "description": "Check is Premium or not",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
+            "type": "boolean"
           },
           "remediation": {
-            "description": "Check remediation",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "A remediation message for the check, providing guidance on resolving issues detected.",
+            "type": "string"
           },
           "severity": {
-            "description": "Check severity: critical|warning",
-            "enum": ["critical", "warning"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "The severity of the check, such as critical or warning, indicating its impact.",
+            "enum": [
+              "critical",
+              "warning"
+            ],
+            "type": "string"
           },
           "values": {
             "items": {
@@ -366,87 +10809,64 @@
                     "additionalProperties": false,
                     "properties": {
                       "expression": {
-                        "description": "Expression to be evaluated to use the current value",
-                        "type": "string",
-                        "x-struct": null,
-                        "x-validate": null
+                        "description": "The expression to be evaluated to use the current value for the check.",
+                        "type": "string"
                       },
                       "value": {
-                        "description": "Value for this condition",
+                        "description": "The value to be used for this condition in the check.",
                         "oneOf": [
                           {
-                            "type": "string",
-                            "x-struct": null,
-                            "x-validate": null
+                            "type": "string"
                           },
                           {
-                            "type": "number",
-                            "x-struct": null,
-                            "x-validate": null
+                            "type": "number"
                           },
                           {
-                            "type": "boolean",
-                            "x-struct": null,
-                            "x-validate": null
+                            "type": "boolean"
                           }
-                        ],
-                        "x-struct": null,
-                        "x-validate": null
+                        ]
                       }
                     },
-                    "required": ["value", "expression"],
-                    "type": "object",
-                    "x-struct": null,
-                    "x-validate": null
+                    "required": [
+                      "value",
+                      "expression"
+                    ],
+                    "type": "object"
                   },
-                  "type": "array",
-                  "x-struct": null,
-                  "x-validate": null
+                  "type": "array"
                 },
                 "default": {
-                  "description": "Default value. Used if none of the conditions matches",
+                  "description": "The default value used if none of the conditions matches for the check.",
                   "oneOf": [
                     {
-                      "type": "string",
-                      "x-struct": null,
-                      "x-validate": null
+                      "type": "string"
                     },
                     {
-                      "type": "number",
-                      "x-struct": null,
-                      "x-validate": null
+                      "type": "number"
                     },
                     {
-                      "type": "boolean",
-                      "x-struct": null,
-                      "x-validate": null
+                      "type": "boolean"
                     }
-                  ],
-                  "x-struct": null,
-                  "x-validate": null
+                  ]
                 },
                 "name": {
-                  "description": "Value name",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "The name of the value used in the check.",
+                  "type": "string"
                 }
               },
-              "required": ["name", "default", "conditions"],
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
+              "required": [
+                "name",
+                "default",
+                "conditions"
+              ],
+              "type": "object"
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           },
           "when": {
-            "description": "Expression to determine whether a check should run",
+            "description": "An expression to determine whether a check should run, allowing for conditional execution.",
             "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "type": "string"
           }
         },
         "required": [
@@ -464,304 +10884,1116 @@
           "premium"
         ],
         "title": "Check",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "type": "object"
       },
-      "SelectableCheck": {
+      "1.5.0_v1_CheckResult": {
         "additionalProperties": false,
+        "description": "Represents the result of a check execution, including expectation evaluations and customization status.",
+        "example": {
+          "agents_check_results": [],
+          "check_id": "SLES-HA-1",
+          "customized": false,
+          "expectation_results": [
+            {
+              "failure_message": "Fencing is not configured for all nodes.",
+              "name": "fencing_enabled",
+              "result": true,
+              "type": "expect"
+            }
+          ],
+          "result": "critical"
+        },
         "properties": {
-          "customizable": {
-            "description": "Whether the check is customizable or not",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "customized": {
-            "description": "Whether the check has been customized or not",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "description": {
-            "description": "Check description",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "group": {
-            "description": "Check group",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "Check ID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Check name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "values": {
+          "agents_check_results": {
+            "description": "The aggregated result of the check execution, summarizing the overall outcome for the check.",
+            "example": [],
             "items": {
               "oneOf": [
                 {
-                  "$ref": "#/components/schemas/CustomizedCheckValue"
+                  "$ref": "#/components/schemas/1.5.0_v1_AgentCheckResult"
                 },
                 {
-                  "$ref": "#/components/schemas/NotCustomizedCheckValue"
+                  "$ref": "#/components/schemas/1.5.0_v1_AgentCheckError"
                 }
-              ],
-              "x-struct": null,
-              "x-validate": null
+              ]
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
+          },
+          "check_id": {
+            "description": "The unique identifier of the check for which the result is reported.",
+            "example": "SLES-HA-1",
+            "type": "string"
+          },
+          "customized": {
+            "description": "Indicates whether the check has been customized for this execution, allowing for tailored validation.",
+            "example": false,
+            "type": "boolean"
+          },
+          "expectation_results": {
+            "description": "List of results for each expectation evaluated during the check, providing detailed outcome information.",
+            "example": [
+              {
+                "failure_message": "Fencing is not configured for all nodes.",
+                "name": "fencing_enabled",
+                "result": true,
+                "type": "expect"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_ExpectationResult"
+            },
+            "type": "array"
+          },
+          "result": {
+            "description": "Aggregated result of the check execution. Possible values are: passing, warning, or critical.",
+            "enum": [
+              "passing",
+              "warning",
+              "critical"
+            ],
+            "example": "critical",
+            "type": "string"
           }
         },
         "required": [
-          "id",
-          "name",
-          "group",
-          "description",
-          "values",
-          "customizable",
-          "customized"
+          "check_id",
+          "expectation_results",
+          "agents_check_results",
+          "result"
         ],
-        "title": "SelectableCheck",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "title": "CheckResult",
+        "type": "object"
       },
-      "ListOperationsResponse": {
+      "1.5.0_v1_CustomValue": {
         "additionalProperties": false,
-        "description": "The paginated list of operations",
+        "description": "Represents a single custom value to be applied or already applied to a check, including its name and overriding value.",
+        "example": {
+          "name": "threshold",
+          "value": 15
+        },
+        "properties": {
+          "name": {
+            "description": "The name of the specific value to be customized for the check.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The overriding value to be applied to the check, replacing the default or previous value for customization purposes.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "value"
+        ],
+        "title": "CustomValue",
+        "type": "object"
+      },
+      "1.5.0_v1_CustomizationRequest": {
+        "additionalProperties": false,
+        "description": "Represents a request to customize a check, including the list of values to be customized for tailored validation.",
+        "example": {
+          "values": [
+            {
+              "name": "threshold",
+              "value": 15
+            },
+            {
+              "name": "enabled",
+              "value": true
+            }
+          ]
+        },
+        "minProperties": 1,
+        "properties": {
+          "values": {
+            "description": "A list of values to be customized for the check, allowing for flexible and targeted configuration.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_CustomValue"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "values"
+        ],
+        "title": "CustomizationRequest",
+        "type": "object"
+      },
+      "1.5.0_v1_CustomizationResponse": {
+        "additionalProperties": false,
+        "description": "Represents the response for a customization operation, including the list of custom values applied to a check.",
+        "example": {
+          "values": [
+            {
+              "name": "threshold",
+              "value": 15
+            },
+            {
+              "name": "enabled",
+              "value": true
+            }
+          ]
+        },
+        "properties": {
+          "values": {
+            "description": "A list of custom values that have been applied to the check, reflecting the customization performed.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_CustomValue"
+            },
+            "type": "array"
+          }
+        },
+        "title": "CustomizationResponse",
+        "type": "object"
+      },
+      "1.5.0_v1_CustomizedCheckValue": {
+        "additionalProperties": false,
+        "description": "Represents a single customized check value, including its name, custom value, default value, and customization status.",
+        "example": {
+          "custom_value": 15,
+          "customizable": true,
+          "default_value": 10,
+          "name": "threshold"
+        },
+        "properties": {
+          "custom_value": {
+            "description": "The custom value that overrides the default value for this check, allowing for tailored validation.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "customizable": {
+            "description": "Indicates whether the check value can be customized for execution, allowing for tailored validation.",
+            "type": "boolean"
+          },
+          "default_value": {
+            "description": "The original value as defined by specification, resolved based on the environment.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "name": {
+            "description": "The name of the customized check value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "custom_value",
+          "default_value",
+          "customizable"
+        ],
+        "title": "CustomizedCheckValue",
+        "type": "object"
+      },
+      "1.5.0_v1_ExecutionEnv": {
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "items": {
+                "$ref": "#/components/schemas/1.5.0_v1_ExecutionEnv"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "description": "Defines the contextual environment settings used during the current execution, allowing for flexible configuration.",
+        "example": {
+          "DEBUG": true,
+          "MAX_RETRIES": 3,
+          "VAR1": "value1"
+        },
+        "title": "ExecutionEnv",
+        "type": "object"
+      },
+      "1.5.0_v1_ExecutionResponse": {
+        "additionalProperties": false,
+        "description": "Represents the details of an execution, including its status, timing, results, and associated targets. Can be running or completed.",
+        "example": {
+          "check_results": [
+            {
+              "agents_check_results": [],
+              "check_id": "SLES-HA-1",
+              "customized": false,
+              "expectation_results": [
+                {
+                  "failure_message": "Fencing is not configured for all nodes.",
+                  "name": "fencing_enabled",
+                  "result": true,
+                  "type": "expect"
+                }
+              ],
+              "result": "critical"
+            }
+          ],
+          "completed_at": "2025-08-04T10:05:00Z",
+          "critical_count": 1,
+          "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+          "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+          "passing_count": 0,
+          "result": "critical",
+          "started_at": "2025-08-04T10:00:00Z",
+          "status": "completed",
+          "targets": [
+            {
+              "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+              "checks": [
+                "SLES-HA-1"
+              ]
+            }
+          ],
+          "timeout": [],
+          "warning_count": 0
+        },
+        "properties": {
+          "check_results": {
+            "description": "The list of check results for this execution, providing detailed outcome information for each check.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_CheckResult"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "completed_at": {
+            "description": "The timestamp indicating when the execution was completed, if applicable.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "critical_count": {
+            "description": "The number of checks that resulted in a critical outcome during the execution.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "execution_id": {
+            "description": "The unique identifier of the execution.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "group_id": {
+            "description": "The unique identifier of the group associated with the execution.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "passing_count": {
+            "description": "The number of checks that passed successfully during the execution.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "result": {
+            "description": "The aggregated result of the execution, summarizing the overall outcome. Unknown for running executions.",
+            "enum": [
+              "passing",
+              "warning",
+              "critical"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "started_at": {
+            "description": "The timestamp indicating when the execution started.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "The current status of the execution, indicating its progress or completion state.",
+            "enum": [
+              "running",
+              "completed"
+            ],
+            "type": "string"
+          },
+          "targets": {
+            "description": "The list of targets involved in the execution.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_Target"
+            },
+            "type": "array"
+          },
+          "timeout": {
+            "description": "A list of agents that timed out during the execution process.",
+            "items": {
+              "description": "The unique identifier of the agent that timed out during the execution.",
+              "format": "uuid",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "warning_count": {
+            "description": "The number of checks that resulted in a warning outcome during the execution.",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "execution_id",
+          "group_id",
+          "status",
+          "started_at",
+          "completed_at",
+          "result",
+          "targets",
+          "critical_count",
+          "warning_count",
+          "passing_count",
+          "timeout",
+          "check_results"
+        ],
+        "title": "ExecutionResponse",
+        "type": "object"
+      },
+      "1.5.0_v1_ExpectationEvaluation": {
+        "additionalProperties": false,
+        "description": "Represents the result of evaluating an expectation, including its name, value, type, and any failure message.",
+        "example": {
+          "failure_message": "Fencing is not configured for all nodes.",
+          "name": "fencing_enabled",
+          "return_value": true,
+          "type": "expect"
+        },
+        "properties": {
+          "failure_message": {
+            "description": "A message describing the failure, only available for scenarios where the expectation was not met.",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the expectation being evaluated.",
+            "type": "string"
+          },
+          "return_value": {
+            "description": "The value returned from the expectation evaluation, indicating the outcome of the check.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "type": {
+            "description": "The type of evaluation performed for the expectation, such as expect or expect_same.",
+            "enum": [
+              "unknown",
+              "expect",
+              "expect_same"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "return_value",
+          "type"
+        ],
+        "title": "ExpectationEvaluation",
+        "type": "object"
+      },
+      "1.5.0_v1_ExpectationEvaluationError": {
+        "additionalProperties": false,
+        "description": "Indicates that an error occurred during the evaluation of an expectation, providing details for troubleshooting.",
+        "example": {
+          "message": "Expression evaluation failed.",
+          "name": "fencing_enabled",
+          "type": "evaluation_error"
+        },
+        "properties": {
+          "message": {
+            "description": "A detailed message describing the error encountered during expectation evaluation.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the expectation for which the error occurred.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of error encountered during expectation evaluation, such as validation or runtime error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "message",
+          "type"
+        ],
+        "title": "ExpectationEvaluationError",
+        "type": "object"
+      },
+      "1.5.0_v1_ExpectationResult": {
+        "additionalProperties": false,
+        "description": "Represents the result of an expectation evaluation, including its name, result, type, and any failure message.",
+        "example": {
+          "failure_message": "Fencing is not configured for all nodes.",
+          "name": "fencing_enabled",
+          "result": true,
+          "type": "expect"
+        },
+        "properties": {
+          "failure_message": {
+            "description": "A message describing the failure, only available for scenarios where the expectation was not met.",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the expectation being evaluated.",
+            "type": "string"
+          },
+          "result": {
+            "description": "Indicates whether the expectation condition was met during evaluation.",
+            "type": "boolean"
+          },
+          "type": {
+            "description": "The type of evaluation performed for the expectation, such as expect or expect_same.",
+            "enum": [
+              "unknown",
+              "expect",
+              "expect_same"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "result",
+          "type"
+        ],
+        "title": "ExpectationResult",
+        "type": "object"
+      },
+      "1.5.0_v1_Fact": {
+        "additionalProperties": false,
+        "description": "Represents a fact gathered during execution, including its check association and observed value.",
+        "example": {
+          "check_id": "SLES-HA-1",
+          "name": "node_count",
+          "value": 3
+        },
+        "properties": {
+          "check_id": {
+            "description": "The unique identifier of the check that produced this fact during execution.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the fact representing the observed property or metric gathered during execution.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value of the fact as observed during execution, which may be a string, integer, boolean, or array.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "check_id",
+          "name",
+          "value"
+        ],
+        "title": "Fact",
+        "type": "object"
+      },
+      "1.5.0_v1_FactError": {
+        "additionalProperties": false,
+        "description": "Indicates that a fact could not be gathered during execution, providing details for troubleshooting data collection issues.",
+        "example": {
+          "check_id": "SLES-HA-1",
+          "message": "Timeout while gathering fact",
+          "name": "node_count",
+          "type": "gathering_error"
+        },
+        "properties": {
+          "check_id": {
+            "description": "The unique identifier of the check for which the fact could not be gathered.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A detailed message describing the error encountered during fact gathering.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the fact that could not be gathered during execution.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of error encountered during fact gathering.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "check_id",
+          "name",
+          "type",
+          "message"
+        ],
+        "title": "FactError",
+        "type": "object"
+      },
+      "1.5.0_v1_Forbidden": {
+        "additionalProperties": false,
+        "description": "This response indicates that access to the requested resource or operation is forbidden due to insufficient permissions.",
+        "example": {
+          "errors": [
+            {
+              "detail": "The requested operation could not be performed.",
+              "title": "Forbidden"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
+              {
+                "detail": "The requested operation could not be performed.",
+                "title": "Forbidden"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "example": "The requested operation could not be performed.",
+                  "type": "string"
+                },
+                "title": {
+                  "example": "Forbidden",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "Forbidden",
+        "type": "object"
+      },
+      "1.5.0_v1_ListExecutionsResponse": {
+        "additionalProperties": false,
+        "description": "Represents a paginated list of executions, including the total count and individual execution items.",
+        "example": {
+          "items": [
+            {
+              "check_results": [
+                {
+                  "agents_check_results": [],
+                  "check_id": "SLES-HA-1",
+                  "customized": false,
+                  "expectation_results": [
+                    {
+                      "failure_message": "Fencing is not configured for all nodes.",
+                      "name": "fencing_enabled",
+                      "result": true,
+                      "type": "expect"
+                    }
+                  ],
+                  "result": "critical"
+                }
+              ],
+              "completed_at": "2025-08-04T10:05:00Z",
+              "critical_count": 1,
+              "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+              "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+              "passing_count": 0,
+              "result": "critical",
+              "started_at": "2025-08-04T10:00:00Z",
+              "status": "completed",
+              "targets": [
+                {
+                  "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+                  "checks": [
+                    "SLES-HA-1"
+                  ]
+                }
+              ],
+              "timeout": [],
+              "warning_count": 0
+            }
+          ],
+          "total_count": 1
+        },
+        "properties": {
+          "items": {
+            "description": "A list of execution items included in the paginated response, each representing an execution instance.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_ExecutionResponse"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "description": "The total number of executions included in the paginated response.",
+            "type": "integer"
+          }
+        },
+        "title": "ListExecutionsResponse",
+        "type": "object"
+      },
+      "1.5.0_v1_ListOperationsResponse": {
+        "additionalProperties": false,
+        "description": "Represents a paginated list of operations, including the total count and individual operation items.",
+        "example": {
+          "items": [
+            {
+              "agent_reports": [
+                {
+                  "agents": [
+                    {
+                      "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+                      "diff": {
+                        "after": "present",
+                        "before": "absent"
+                      },
+                      "error_message": "",
+                      "result": "updated"
+                    }
+                  ],
+                  "name": "install_package",
+                  "operator": "equals",
+                  "predicate": "package_installed == true",
+                  "timeout": 60
+                }
+              ],
+              "completed_at": "2025-08-04T10:02:00Z",
+              "description": "A sample operation that installs the NGINX package on target agents for demonstration purposes.",
+              "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+              "name": "Install NGINX",
+              "operation": "install_package",
+              "operation_id": "985edb19-cb1d-463e-81c2-53a4fa85d1fa",
+              "result": "updated",
+              "started_at": "2025-08-04T10:00:00Z",
+              "status": "completed",
+              "targets": [
+                {
+                  "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+                  "arguments": {
+                    "package": "nginx",
+                    "version": "1.18.0"
+                  }
+                }
+              ],
+              "updated_at": "2025-08-04T10:01:00Z"
+            }
+          ],
+          "total_count": 1
+        },
         "properties": {
           "items": {
             "items": {
-              "$ref": "#/components/schemas/OperationResponse"
+              "$ref": "#/components/schemas/1.5.0_v1_OperationResponse"
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           },
           "total_count": {
-            "description": "Total count of operations",
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
+            "description": "The total number of operations included in the paginated response.",
+            "type": "integer"
           }
         },
         "title": "ListOperationsResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "type": "object"
       },
-      "AgentCheckResult": {
-        "description": "The result of check on a specific agent",
+      "1.5.0_v1_NotCustomizedCheckValue": {
+        "additionalProperties": false,
+        "description": "Represents a check value that has not been customized, including its name, default value, and customization status.",
+        "example": {
+          "customizable": true,
+          "default_value": 10,
+          "name": "threshold"
+        },
         "properties": {
-          "agent_id": {
-            "description": "Agent ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "customizable": {
+            "description": "Indicates whether the check value can be customized for execution, allowing for tailored validation.",
+            "type": "boolean"
           },
-          "expectation_evaluations": {
-            "description": "Result of the single expectation evaluation",
-            "items": {
-              "type": "object"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+          "default_value": {
+            "description": "The original value as defined by specification, resolved based on the environment. Absent if value is not customizable.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              {
+                "type": "boolean"
+              }
+            ]
           },
-          "facts": {
-            "description": "Facts gathered from the targets",
-            "items": {
-              "type": "object"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "values": {
-            "description": "Values resolved for the current execution",
-            "items": {
-              "type": "object"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+          "name": {
+            "description": "The name of the check value that has not been customized.",
+            "type": "string"
           }
         },
-        "required": ["agent_id", "facts", "expectation_evaluations"],
-        "title": "AgentCheckResult",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "required": [
+          "name",
+          "customizable"
+        ],
+        "title": "NotCustomizedCheckValue",
+        "type": "object"
       },
-      "AcceptedExecutionResponse": {
+      "1.5.0_v1_NotFound": {
         "additionalProperties": false,
-        "description": "Identifiers of the recently accepted execution",
+        "description": "This response indicates that the requested resource could not be found in the system.",
+        "example": {
+          "errors": [
+            {
+              "detail": "The requested resource cannot be found.",
+              "title": "Not Found"
+            }
+          ]
+        },
         "properties": {
-          "execution_id": {
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "errors": {
+            "example": [
+              {
+                "detail": "The requested resource cannot be found.",
+                "title": "Not Found"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "example": "The requested resource cannot be found.",
+                  "type": "string"
+                },
+                "title": {
+                  "example": "Not Found",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "NotFound",
+        "type": "object"
+      },
+      "1.5.0_v1_OperationResponse": {
+        "additionalProperties": false,
+        "description": "Represents the details of an operation, including its status, timing, results, and associated targets. Can be running or completed.",
+        "example": {
+          "agent_reports": [
+            {
+              "agents": [
+                {
+                  "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+                  "diff": {
+                    "after": "present",
+                    "before": "absent"
+                  },
+                  "error_message": "",
+                  "result": "updated"
+                }
+              ],
+              "name": "install_package",
+              "operator": "equals",
+              "predicate": "package_installed == true",
+              "timeout": 60
+            }
+          ],
+          "completed_at": "2025-08-04T10:02:00Z",
+          "description": "A sample operation that installs the NGINX package on target agents for demonstration purposes.",
+          "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+          "name": "Install NGINX",
+          "operation": "install_package",
+          "operation_id": "985edb19-cb1d-463e-81c2-53a4fa85d1fa",
+          "result": "updated",
+          "started_at": "2025-08-04T10:00:00Z",
+          "status": "completed",
+          "targets": [
+            {
+              "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+              "arguments": {
+                "package": "nginx",
+                "version": "1.18.0"
+              }
+            }
+          ],
+          "updated_at": "2025-08-04T10:01:00Z"
+        },
+        "properties": {
+          "agent_reports": {
+            "description": "A list of reports from agents involved in the operation, providing detailed outcome information.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_StepReport"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "completed_at": {
+            "description": "The timestamp indicating when the operation was completed, if applicable.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the operation, outlining its purpose and expected behavior.",
+            "type": "string"
           },
           "group_id": {
+            "description": "The unique identifier of the group associated with the operation.",
             "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "AcceptedExecutionResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ExpectationResult": {
-        "additionalProperties": false,
-        "description": "The result of an expectation",
-        "properties": {
-          "failure_message": {
-            "description": "Failure message. Only available for `expect_same` scenarios",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "type": "string"
           },
           "name": {
-            "description": "Expectation name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "The name of the operation being performed.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "The type of operation executed, specifying the action performed.",
+            "type": "string"
+          },
+          "operation_id": {
+            "description": "The unique identifier of the operation.",
+            "format": "uuid",
+            "type": "string"
           },
           "result": {
-            "description": "Result of the expectation condition",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
+            "description": "The aggregated result of the operation, summarizing the overall outcome. Unknown for running operations.",
+            "enum": [
+              "updated",
+              "not_updated",
+              "failed",
+              "rolled_back",
+              "timeout",
+              "skipped",
+              "not_executed"
+            ],
+            "nullable": true,
+            "type": "string"
           },
-          "type": {
-            "description": "Evaluation type",
-            "enum": ["unknown", "expect", "expect_same"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "started_at": {
+            "description": "The timestamp indicating when the operation started.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "The current status of the operation, indicating its progress or completion state.",
+            "enum": [
+              "running",
+              "completed",
+              "aborted"
+            ],
+            "type": "string"
+          },
+          "targets": {
+            "description": "The list of targets involved in the operation.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_OperationTarget"
+            },
+            "type": "array"
+          },
+          "updated_at": {
+            "description": "The timestamp indicating when the operation was last updated.",
+            "format": "date-time",
+            "type": "string"
           }
         },
-        "required": ["name", "result", "type"],
-        "title": "ExpectationResult",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "title": "OperationResponse",
+        "type": "object"
       },
-      "FactError": {
+      "1.5.0_v1_OperationTarget": {
         "additionalProperties": false,
-        "description": "An error describing that a fact could not be gathered",
+        "description": "Represents the target where operations are executed, including agent identification and arguments for execution.",
+        "example": {
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "arguments": {
+            "package": "nginx",
+            "version": "1.18.0"
+          }
+        },
         "properties": {
-          "check_id": {
-            "description": "Check ID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "agent_id": {
+            "description": "The unique identifier of the agent where the operation is executed.",
+            "format": "uuid",
+            "type": "string"
           },
-          "message": {
-            "description": "Error message",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Fact name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "type": {
-            "description": "Error type",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "arguments": {
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "description": "A map of arguments provided for the operation execution, allowing for flexible configuration.",
+            "type": "object"
           }
         },
-        "required": ["check_id", "name", "type", "message"],
-        "title": "FactError",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "required": [
+          "agent_id",
+          "arguments"
+        ],
+        "title": "OperationTarget",
+        "type": "object"
       },
-      "SelectableChecksResponse": {
+      "1.5.0_v1_SelectableChecksResponse": {
         "additionalProperties": false,
-        "description": "List of selectable checks for a given execution group and environment",
+        "description": "Represents the list of selectable checks for a given execution group and environment, including details for customization and selection.",
+        "example": {
+          "items": [
+            {
+              "customizable": true,
+              "customized": false,
+              "description": "A sample selectable check for demonstration purposes, showing customization and selection options.",
+              "group": "group_a",
+              "id": "check_1",
+              "name": "Check 1",
+              "values": [
+                {
+                  "custom_value": 15,
+                  "customizable": true,
+                  "default_value": 10,
+                  "name": "threshold"
+                },
+                {
+                  "customizable": false,
+                  "default_value": true,
+                  "name": "enabled"
+                }
+              ]
+            }
+          ]
+        },
         "properties": {
           "items": {
-            "description": "List of Selectable Checks",
+            "description": "A list of selectable checks available for execution, each with customization options and metadata.",
             "items": {
               "additionalProperties": false,
+              "description": "A check that can be selected and customized for execution, providing flexibility in validation and reporting.",
               "properties": {
                 "customizable": {
-                  "description": "Whether the check is customizable or not",
-                  "type": "boolean",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "Indicates whether the check can be customized for execution, allowing for tailored validation.",
+                  "type": "boolean"
                 },
                 "customized": {
-                  "description": "Whether the check has been customized or not",
-                  "type": "boolean",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "Indicates whether the check has already been customized for execution, reflecting user modifications.",
+                  "type": "boolean"
                 },
                 "description": {
-                  "description": "Check description",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "A description of the selectable check, outlining its purpose and expected behavior.",
+                  "type": "string"
                 },
                 "group": {
-                  "description": "Check group",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "The group to which the selectable check belongs.",
+                  "type": "string"
                 },
                 "id": {
-                  "description": "Check ID",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "The unique identifier of the check available for selection.",
+                  "type": "string"
                 },
                 "name": {
-                  "description": "Check name",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "description": "The name of the check available for selection and customization.",
+                  "type": "string"
                 },
                 "values": {
+                  "example": [
+                    {
+                      "custom_value": 15,
+                      "customizable": true,
+                      "default_value": 10,
+                      "name": "threshold"
+                    },
+                    {
+                      "customizable": false,
+                      "default_value": true,
+                      "name": "enabled"
+                    }
+                  ],
                   "items": {
                     "oneOf": [
                       {
-                        "$ref": "#/components/schemas/CustomizedCheckValue"
+                        "$ref": "#/components/schemas/1.5.0_v1_CustomizedCheckValue"
                       },
                       {
-                        "$ref": "#/components/schemas/NotCustomizedCheckValue"
+                        "$ref": "#/components/schemas/1.5.0_v1_NotCustomizedCheckValue"
                       }
-                    ],
-                    "x-struct": null,
-                    "x-validate": null
+                    ]
                   },
-                  "type": "array",
-                  "x-struct": null,
-                  "x-validate": null
+                  "type": "array"
                 }
               },
               "required": [
@@ -773,5459 +12005,1853 @@
                 "customizable",
                 "customized"
               ],
-              "title": "SelectableCheck",
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
+              "type": "object"
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           }
         },
         "title": "SelectableChecksResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ExecutionEnv": {
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            },
-            {
-              "type": "boolean",
-              "x-struct": null,
-              "x-validate": null
-            },
-            {
-              "items": {
-                "$ref": "#/components/schemas/ExecutionEnv"
-              },
-              "type": "array",
-              "x-struct": null,
-              "x-validate": null
-            }
-          ],
-          "x-struct": null,
-          "x-validate": null
-        },
-        "description": "Contextual Environment for the current execution",
-        "title": "ExecutionEnv",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "CustomizedCheckValue": {
-        "additionalProperties": false,
-        "description": "A single customized check value",
-        "properties": {
-          "custom_value": {
-            "description": "Represents the custom value that overrides the current one.",
-            "oneOf": [
-              {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "anyOf": [
-                  {
-                    "type": "integer",
-                    "x-struct": null,
-                    "x-validate": null
-                  },
-                  {
-                    "type": "number",
-                    "x-struct": null,
-                    "x-validate": null
-                  }
-                ],
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "boolean",
-                "x-struct": null,
-                "x-validate": null
-              }
-            ],
-            "x-struct": null,
-            "x-validate": null
-          },
-          "customizable": {
-            "description": "Whether the check is customizable or not",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "default_value": {
-            "description": "Original value as defined by specification. Resolved based on the environment.",
-            "oneOf": [
-              {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "anyOf": [
-                  {
-                    "type": "integer",
-                    "x-struct": null,
-                    "x-validate": null
-                  },
-                  {
-                    "type": "number",
-                    "x-struct": null,
-                    "x-validate": null
-                  }
-                ],
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "boolean",
-                "x-struct": null,
-                "x-validate": null
-              }
-            ],
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Value name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["name", "custom_value", "default_value", "customizable"],
-        "title": "CustomizedCheckValue",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "CustomizationRequest": {
-        "additionalProperties": false,
-        "description": "Request to customize a check",
-        "minProperties": 1,
-        "properties": {
-          "values": {
-            "description": "List of values to customize",
-            "items": {
-              "$ref": "#/components/schemas/CustomValue"
-            },
-            "minItems": 1,
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["values"],
-        "title": "CustomizationRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Target": {
-        "additionalProperties": false,
-        "description": "Target where execution facts are gathered",
-        "properties": {
-          "agent_id": {
-            "description": "Agent ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "checks": {
-            "items": {
-              "description": "Check ID",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["agent_id", "checks"],
-        "title": "Target",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ExpectationEvaluation": {
-        "additionalProperties": false,
-        "description": "Evaluation of an expectation",
-        "properties": {
-          "failure_message": {
-            "description": "Failure message. Only available for `expect` scenarios",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "return_value": {
-            "description": "Return value",
-            "oneOf": [
-              {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "number",
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "boolean",
-                "x-struct": null,
-                "x-validate": null
-              }
-            ],
-            "x-struct": null,
-            "x-validate": null
-          },
-          "type": {
-            "description": "Evaluation type",
-            "enum": ["unknown", "expect", "expect_same"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["name", "return_value", "type"],
-        "title": "ExpectationEvaluation",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AgentCheckError": {
-        "nullable": false,
-        "additionalProperties": false,
-        "description": "An error describing that some of the facts could not be gathered on a specific agent eg. gathering failure or timeout",
-        "properties": {
-          "agent_id": {
-            "description": "Agent ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "facts": {
-            "description": "Facts gathered, possibly with errors, from the target",
-            "items": {
-              "type": "object"
-            },
-            "nullable": false,
-            "type": "array"
-          },
-          "message": {
-            "description": "Error message",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "type": {
-            "description": "Error type",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["agent_id", "type", "message"],
-        "title": "AgentCheckError",
         "type": "object"
       },
-      "StepReport": {
+      "1.5.0_v1_StartExecutionRequest": {
         "additionalProperties": false,
-        "description": "Operation step report",
-        "properties": {
-          "agents": {
-            "items": {
-              "$ref": "#/components/schemas/AgentReport"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+        "description": "Defines the context required to run a check execution, including execution and group identifiers, targets, and environment settings.",
+        "example": {
+          "env": {
+            "VAR1": "value1"
           },
-          "name": {
-            "description": "Operation step name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "operator": {
-            "description": "Operation step operator",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "predicate": {
-            "description": "Operation step predicate",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "timeout": {
-            "description": "Operation step timeout",
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          }
+          "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+          "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+          "targets": [
+            {
+              "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+              "checks": [
+                "SLES-HA-1"
+              ]
+            }
+          ]
         },
-        "required": ["name", "operator", "predicate", "timeout", "agents"],
-        "title": "StepReport",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "OperationTarget": {
-        "additionalProperties": false,
-        "description": "Target where operations are executed",
         "properties": {
-          "agent_id": {
-            "description": "Agent ID",
+          "env": {
+            "$ref": "#/components/schemas/1.5.0_v1_ExecutionEnv"
+          },
+          "execution_id": {
+            "description": "The unique identifier for the execution instance.",
+            "example": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
             "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "arguments": {
-            "additionalProperties": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                {
-                  "type": "integer",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                {
-                  "type": "boolean",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              ],
-              "x-struct": null,
-              "x-validate": null
-            },
-            "description": "Arguments map",
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["agent_id", "arguments"],
-        "title": "OperationTarget",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "OperationResponse": {
-        "additionalProperties": false,
-        "description": "The representation of an operation, it may be a running or completed one",
-        "properties": {
-          "agent_reports": {
-            "items": {
-              "$ref": "#/components/schemas/StepReport"
-            },
-            "nullable": true,
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "completed_at": {
-            "description": "Operation completion time",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "description": {
-            "description": "Operation description",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "type": "string"
           },
           "group_id": {
-            "description": "Group ID",
+            "description": "The unique identifier for the group associated with the execution instance.",
+            "example": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
             "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "type": "string"
           },
-          "name": {
-            "description": "Operation name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "operation": {
-            "description": "Executed operation",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "operation_id": {
-            "description": "Operation ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "result": {
-            "description": "Aggregated result of the operation, unknown for running ones",
-            "enum": [
-              "updated",
-              "not_updated",
-              "failed",
-              "rolled_back",
-              "timeout",
-              "skipped",
-              "not_executed"
-            ],
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "started_at": {
-            "description": "Operation start time",
-            "format": "date-time",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "status": {
-            "description": "The status of the current operation",
-            "enum": ["running", "completed", "aborted"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "target_type": {
+            "description": "The type of target for the execution, specifying the nature of the execution environment.",
+            "example": "host",
+            "type": "string"
           },
           "targets": {
-            "items": {
-              "$ref": "#/components/schemas/OperationTarget"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "description": "Operation last update time",
-            "format": "date-time",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "OperationResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ListExecutionsResponse": {
-        "additionalProperties": false,
-        "description": "The paginated list of executions",
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ExecutionResponse"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "total_count": {
-            "description": "Total count of executions",
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "ListExecutionsResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AgentReport": {
-        "additionalProperties": false,
-        "description": "Individual agent report of an operation",
-        "properties": {
-          "agent_id": {
-            "description": "Agent ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "diff": {
-            "additionalProperties": false,
-            "description": "The operation before/after difference",
-            "nullable": true,
-            "properties": {
-              "after": {
-                "description": "The state after applying the operation",
-                "x-struct": null,
-                "x-validate": null
-              },
-              "before": {
-                "description": "The state before applying the operation",
-                "x-struct": null,
-                "x-validate": null
-              }
-            },
-            "required": ["before", "after"],
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "error_message": {
-            "description": "Error message in case of a failed operation",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "result": {
-            "enum": [
-              "updated",
-              "not_updated",
-              "failed",
-              "rolled_back",
-              "timeout",
-              "skipped",
-              "not_executed"
-            ],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["agent_id", "result", "diff", "error_message"],
-        "title": "AgentReport",
-        "type": "object"
-      },
-      "CatalogResponse": {
-        "additionalProperties": false,
-        "description": "Checks catalog listing response",
-        "properties": {
-          "items": {
-            "description": "List of catalog checks",
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "CatalogResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "CustomValue": {
-        "additionalProperties": false,
-        "description": "A single custom value to be applied or already applied to a check",
-        "properties": {
-          "name": {
-            "description": "Name of the specific value to be customized",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "value": {
-            "description": "Overriding value",
-            "oneOf": [
+            "description": "A list of target agents involved in the execution, each specified by their unique identifier.",
+            "example": [
               {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "integer",
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "boolean",
-                "x-struct": null,
-                "x-validate": null
+                "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+                "checks": [
+                  "SLES-HA-1"
+                ]
               }
             ],
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["name", "value"],
-        "title": "CustomValue",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Tags": {
-        "description": "A list of tags attached to a resource",
-        "items": {
-          "$ref": "#/components/schemas/Tag"
-        },
-        "title": "Tags",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "NotFound": {
-        "additionalProperties": false,
-        "properties": {
-          "errors": {
             "items": {
-              "properties": {
-                "detail": {
-                  "example": "The requested resource cannot be found.",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "title": {
-                  "example": "Not Found",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
+              "$ref": "#/components/schemas/1.5.0_v1_Target"
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "NotFound",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "CVEs": {
-        "additionalProperties": false,
-        "description": "List of CVEs applicable to the errata with the given advisory name.",
-        "items": {
-          "description": "A fix for a publicly known security vulnerability",
-          "title": "CVE",
-          "type": "string",
-          "x-struct": null,
-          "x-validate": null
-        },
-        "title": "CVEs",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PatchesForPackages": {
-        "description": "A list of the relevant patches covered by the provided package upgrades",
-        "items": {
-          "$ref": "#/components/schemas/PatchesForPackage"
-        },
-        "title": "PatchesForPackages",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ActivityLog": {
-        "description": "Activity Log for the current installation.",
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/ActivityLogEntries"
-          },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
-        },
-        "required": ["data", "pagination"],
-        "title": "ActivityLog",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HostMemoryChart": {
-        "additionalProperties": false,
-        "description": "A Time series chart with information about the memory usage of a host",
-        "properties": {
-          "ram_cache_and_buffer": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "ram_free": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "ram_total": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "ram_used": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "swap_used": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          }
-        },
-        "title": "HostMemoryChart",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PacemakerCluster": {
-        "additionalProperties": false,
-        "description": "A discovered Pacemaker Cluster on the target infrastructure",
-        "properties": {
-          "additional_sids": {
-            "description": "Additionally discovered SIDs, such as ASCS/ERS cluster SIDs",
-            "items": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "cib_last_written": {
-            "description": "CIB last written date",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "details": {
-            "$ref": "#/components/schemas/PacemakerClusterDetails"
-          },
-          "health": {
-            "$ref": "#/components/schemas/ResourceHealth"
-          },
-          "hosts_number": {
-            "description": "Hosts number",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "Cluster ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "inserted_at": {
-            "format": "datetime",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Cluster name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "provider": {
-            "$ref": "#/components/schemas/SupportedProviders"
-          },
-          "resources_number": {
-            "description": "Resource number",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "selected_checks": {
-            "description": "A list of check ids selected for an execution on this cluster",
-            "items": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "title": "SelectedChecks",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sid": {
-            "description": "SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "tags": {
-            "$ref": "#/components/schemas/Tags"
-          },
-          "type": {
-            "description": "Detected type of the cluster",
-            "enum": ["hana_scale_up", "hana_scale_out", "unknown"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PacemakerCluster",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaptuneSolution": {
-        "additionalProperties": false,
-        "description": "Saptune solution",
-        "properties": {
-          "id": {
-            "description": "Saptune solution ID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "notes": {
-            "description": "Solution note IDs",
-            "items": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "partial": {
-            "description": "Solution is partially applied",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Saptune solution",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "DatabaseInstances": {
-        "description": "A list of DatabaseInstances, part of a complete SAP System, or only a HANA Database",
-        "items": {
-          "$ref": "#/components/schemas/DatabaseInstance"
-        },
-        "title": "DatabaseInstances",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ChartTimeSeries": {
-        "additionalProperties": false,
-        "description": "A Time Series for a chart, has a series of float values distributed through time",
-        "properties": {
-          "label": {
-            "description": "The name of series",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "series": {
-            "description": "The values of the series",
-            "items": {
-              "description": "A timestamp/value pair",
-              "properties": {
-                "timestamp": {
-                  "description": "ISO8601 timestamp",
-                  "format": "date-time",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "value": {
-                  "description": "Float value",
-                  "example": 270396.203,
-                  "format": "float",
-                  "type": "number",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "ChartTimeSeries",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "GcpProviderData": {
-        "additionalProperties": false,
-        "description": "GCP detected metadata",
-        "properties": {
-          "disk_number": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "image": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "instance_name": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "machine_type": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "network": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "project_id": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "zone": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "GcpProviderData",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "DatabasesCollection": {
-        "description": "A list of the discovered HANA Databases",
-        "items": {
-          "$ref": "#/components/schemas/Database"
-        },
-        "title": "DatabasesCollection",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ApiKeySettings": {
-        "additionalProperties": false,
-        "description": "Settings for Api Key generation",
-        "properties": {
-          "created_at": {
-            "description": "The creation date of api key",
-            "format": "date-time",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "expire_at": {
-            "description": "The expire date of api key",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "generated_api_key": {
-            "description": "The generated api key from api key settings",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["generated_api_key", "expire_at", "created_at"],
-        "title": "ApiKeySettings",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PatchesForPackage": {
-        "additionalProperties": false,
-        "description": "Relevant patches covered by a package upgrade",
-        "properties": {
-          "package_id": {
-            "description": "To package id",
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "patches": {
-            "additionalProperties": false,
-            "items": {
-              "additionalProperties": false,
-              "description": "A list of relevant patches that the upgrade covers",
-              "properties": {
-                "advisory": {
-                  "description": "Advisory name for the patch",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "advisory_type": {
-                  "description": "Advisory type",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "issue_date": {
-                  "description": "Advisory issue date",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "last_modified_date": {
-                  "description": "Advisory last modified date",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "synopsis": {
-                  "description": "Advisory synopsis for the patch",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "title": "PatchForPackage",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PatchesForPackage",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "CVE": {
-        "description": "A fix for a publicly known security vulnerability",
-        "title": "CVE",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "RefreshedCredentials": {
-        "example": {
-          "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A",
-          "expires_in": 600
-        },
-        "properties": {
-          "access_token": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "expires_in": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "RefreshedCredentials",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "IPv6": {
-        "format": "ipv6",
-        "title": "IPv6",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ChecksSelectionRequest": {
-        "additionalProperties": false,
-        "description": "A list of desired checks that should be executed on the target infrastructure",
-        "properties": {
-          "checks": {
-            "items": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["checks"],
-        "title": "ChecksSelectionRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ResourceHealth": {
-        "description": "Detected health of a Resource",
-        "enum": ["passing", "warning", "critical", "unknown"],
-        "nullable": true,
-        "title": "ResourceHealth",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserTOTPEnrollmentPayload": {
-        "additionalProperties": false,
-        "description": "Trento User TOTP enrollment payload",
-        "properties": {
-          "secret": {
-            "description": "TOTP secret",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "secret_qr_encoded": {
-            "description": "TOTP secret qr encoded",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["secret", "secret_qr_encoded"],
-        "title": "UserTOTPEnrollmentPayload",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaveSuseManagerSettingsRequest": {
-        "additionalProperties": false,
-        "description": "Request body for saving SUMA settings",
-        "properties": {
-          "ca_cert": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "url": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["url", "username", "password"],
-        "title": "SaveSuseManagerSettingsRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AffectedPackages": {
-        "additionalProperties": false,
-        "description": "Response returned from the get affected packages endpoint",
-        "items": {
-          "description": "Metadata for a package effected by an advisory",
-          "properties": {
-            "arch_label": {
-              "description": "Package architecture",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "epoch": {
-              "description": "Package epoch number",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "name": {
-              "description": "Package name",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "release": {
-              "description": "Package RPM release number",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "version": {
-              "description": "Package upstream version",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          "title": "AffectedPackage",
-          "type": "object",
-          "x-struct": null,
-          "x-validate": null
-        },
-        "title": "AffectedPackages",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PatchesForPackagesResponse": {
-        "additionalProperties": false,
-        "description": "Response returned from the patches for packages endpoint",
-        "properties": {
-          "patches": {
-            "description": "A list of the relevant patches covered by the provided package upgrades",
-            "items": {
-              "$ref": "#/components/schemas/PatchesForPackage"
-            },
-            "title": "PatchesForPackages",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PatchesForPackagesResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HostCpuChart": {
-        "additionalProperties": false,
-        "description": "A Time Series chart with information about the cpu usage of a host",
-        "properties": {
-          "busy_iowait": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "busy_irqs": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "busy_other": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "busy_system": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "busy_user": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          },
-          "idle": {
-            "$ref": "#/components/schemas/ChartTimeSeries"
-          }
-        },
-        "title": "HostCpuChart",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SuseManagerSettings": {
-        "additionalProperties": false,
-        "description": "Settings for SUSE Manager",
-        "properties": {
-          "ca_uploaded_at": {
-            "description": "Time that SSL certificate was uploaded.",
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "url": {
-            "description": "URL of SUSE Manager",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "description": "Username",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "SuseManagerSettings",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AffectedSystem": {
-        "description": "Metadata for a system effected by an advisory",
-        "properties": {
-          "name": {
-            "description": "System name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "AffectedSystem",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "GeneralInformation": {
-        "additionalProperties": false,
-        "description": "General information about the current installation",
-        "properties": {
-          "flavor": {
-            "deprecated": true,
-            "description": "Flavor of the current installation",
-            "enum": ["Community", "Premium"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sles_subscriptions": {
-            "description": "The number of SLES Subscription discovered on the target infrastructure",
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "version": {
-            "description": "Version of the current server component installation",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "GeneralInformation",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UpgradablePackages": {
-        "description": "A list of upgradable packages for the host",
-        "items": {
-          "$ref": "#/components/schemas/UpgradablePackage"
-        },
-        "title": "UpgradablePackages",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Unauthorized": {
-        "additionalProperties": false,
-        "properties": {
-          "errors": {
-            "items": {
-              "properties": {
-                "detail": {
-                  "example": "The requested operation could not be authorized.",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "title": {
-                  "example": "Unauthorized",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Unauthorized",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PlatformSettings": {
-        "additionalProperties": false,
-        "description": "Settings values for the current installation",
-        "properties": {
-          "eula_accepted": {
-            "deprecated": true,
-            "description": "Whether the user has accepted EULA",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "premium_subscription": {
-            "deprecated": true,
-            "description": "Whether current installation is a Premium one",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PlatformSettings",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ActivityLogSettings": {
-        "additionalProperties": false,
-        "description": "Activity Log settings of the current installation",
-        "properties": {
-          "retention_time": {
-            "$ref": "#/components/schemas/RetentionTimeSettings"
-          }
-        },
-        "required": ["retention_time"],
-        "title": "ActivityLogSettings",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PublicKey": {
-        "properties": {
-          "content": {
-            "description": "Public key content",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PublicKey",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UpgradablePackage": {
-        "additionalProperties": false,
-        "description": "Upgradable package",
-        "properties": {
-          "arch": {
-            "description": "Package name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "from_epoch": {
-            "description": "From epoch",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "from_release": {
-            "description": "From which release",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "from_version": {
-            "description": "From version",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Upgradable package name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "to_epoch": {
-            "description": "To epoch",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "to_package_id": {
-            "description": "To package id",
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "to_release": {
-            "description": "To release",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "to_version": {
-            "description": "To version",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "UpgradablePackage",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Forbidden": {
-        "additionalProperties": false,
-        "properties": {
-          "errors": {
-            "items": {
-              "properties": {
-                "detail": {
-                  "example": "The requested operation could not be performed.",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "title": {
-                  "example": "Forbidden",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Forbidden",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HealthOverview": {
-        "description": "A list of health summaries for the discovered SAP Systems",
-        "items": {
-          "$ref": "#/components/schemas/SAPSystemHealthOverview"
-        },
-        "title": "HealthOverview",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "RelevantPatches": {
-        "description": "A list relevant patches for the host",
-        "items": {
-          "$ref": "#/components/schemas/RelevantPatch"
-        },
-        "title": "RelevantPatches",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ClusterOperationParams": {
-        "type": "object",
-        "description": "Cluster operation request parameters",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ClusterMaintenanceChangeParams"
-          }
-        ],
-        "title": "ClusterOperationParams",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "LastHeartbeatTimestamp": {
-        "description": "Timestamp of the last heartbeat received from the host",
-        "format": "date-time",
-        "nullable": true,
-        "title": "LastHeartbeatTimestamp",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PacemakerClusterDetails": {
-        "type": "object",
-        "description": "Details of the detected PacemakerCluster",
-        "nullable": true,
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/HanaClusterDetails"
-          }
-        ],
-        "title": "PacemakerClusterDetails",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SAPSystemsCollection": {
-        "description": "A list of the discovered SAP Systems",
-        "items": {
-          "$ref": "#/components/schemas/SAPSystem"
-        },
-        "title": "SAPSystemsCollection",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PatchForPackage": {
-        "additionalProperties": false,
-        "description": "A list of relevant patches that the upgrade covers",
-        "properties": {
-          "advisory": {
-            "description": "Advisory name for the patch",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "advisory_type": {
-            "description": "Advisory type",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "issue_date": {
-            "description": "Advisory issue date",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "last_modified_date": {
-            "description": "Advisory last modified date",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "synopsis": {
-            "description": "Advisory synopsis for the patch",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PatchForPackage",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PrometheusExporterStatus": {
-        "additionalProperties": {
-          "description": "Status of the exporter, the value could be one of passing, critical, unknown",
-          "enum": ["critical", "passing", "unknown"],
-          "type": "string",
-          "x-struct": null,
-          "x-validate": null
-        },
-        "example": {
-          "Node exporter": "critical"
-        },
-        "title": "PrometheusExporterStatus",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ClusterResource": {
-        "additionalProperties": false,
-        "description": "A Cluster Resource",
-        "properties": {
-          "fail_count": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "role": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "status": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "type": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "ClusterResource",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AzureProviderData": {
-        "additionalProperties": false,
-        "description": "Azure detected metadata",
-        "properties": {
-          "admin_username": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "data_disk_number": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "location": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "offer": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "resource_group": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sku": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "vm_size": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "AzureProviderData",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PreconditionFailed": {
-        "additionalProperties": false,
-        "properties": {
-          "errors": {
-            "items": {
-              "properties": {
-                "detail": {
-                  "example": "Mid-air collision detected, please refresh the resource you are trying to update.",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "title": {
-                  "example": "Precondition Failed",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PreconditionFailed",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserIDPEnrollmentCredentials": {
-        "example": {
-          "code": "kyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYt",
-          "session_state": "frHteBttgtW8706m7nqYC6ruYt"
-        },
-        "properties": {
-          "code": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "session_state": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["code", "session_state"],
-        "title": "UserIDPEnrollmentCredentials",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaptuneSolutionApplyParams": {
-        "additionalProperties": false,
-        "description": "Saptune solution apply operation params",
-        "properties": {
-          "solution": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["solution"],
-        "title": "SaptuneSolutionApplyParams",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserItem": {
-        "additionalProperties": false,
-        "description": "User entity in the system",
-        "properties": {
-          "abilities": {
-            "$ref": "#/components/schemas/AbilityCollection"
-          },
-          "analytics_enabled": {
-            "description": "Whether user analytics collection is enabled",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "created_at": {
-            "description": "Date of user creation",
-            "format": "date-time",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "email": {
-            "description": "User email",
-            "format": "email",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "enabled": {
-            "description": "User enabled in the system",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "fullname": {
-            "description": "User full name",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "User ID",
-            "nullable": false,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "idp_user": {
-            "description": "User coming from an external IDP",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password_change_requested_at": {
-            "description": "Date of password change request",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "totp_enabled_at": {
-            "description": "Date of TOTP enrollment",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "description": "Date of user last update",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "description": "User username",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["username", "id", "fullname", "email", "created_at"],
-        "title": "UserItem",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaptuneNote": {
-        "additionalProperties": false,
-        "description": "Saptune note",
-        "properties": {
-          "additionally_enabled": {
-            "description": "Note is additionally enabled",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "Saptune note ID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Saptune note",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PacemakerClustersCollection": {
-        "description": "A list of the discovered Pacemaker Clusters",
-        "items": {
-          "$ref": "#/components/schemas/PacemakerCluster"
-        },
-        "title": "PacemakerClustersCollection",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ErrataDetailsResponse": {
-        "additionalProperties": false,
-        "description": "Response returned from the errata details endpoint",
-        "properties": {
-          "affected_packages": {
-            "$ref": "#/components/schemas/AffectedPackages"
-          },
-          "affected_systems": {
-            "$ref": "#/components/schemas/AffectedSystems"
-          },
-          "cves": {
-            "$ref": "#/components/schemas/CVEs"
-          },
-          "errata_details": {
-            "$ref": "#/components/schemas/ErrataDetails"
-          },
-          "fixes": {
-            "$ref": "#/components/schemas/AdvisoryFixes"
-          }
-        },
-        "title": "ErrataDetailsResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserIDPCredentials": {
-        "example": {
-          "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A",
-          "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A"
-        },
-        "properties": {
-          "access_token": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "refresh_token": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "UserIDPCredentials",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "StartStopParams": {
-        "additionalProperties": false,
-        "description": "SAP instance start/stop operation params",
-        "properties": {
-          "timeout": {
-            "description": "Timeout in seconds to wait until instance is started/stopped",
-            "type": "number",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "StartStopParams",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserProfileUpdateRequest": {
-        "additionalProperties": false,
-        "description": "Request body to update a user profile",
-        "properties": {
-          "analytics_enabled": {
-            "description": "Whether user analytics collection is enabled",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "current_password": {
-            "description": "User current password, used to set a new password",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "email": {
-            "description": "User email",
-            "format": "email",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "fullname": {
-            "description": "User full name",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password": {
-            "description": "User new password",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password_confirmation": {
-            "description": "User new password, should be the same as password field",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "UserProfileUpdateRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserTOTPEnrollmentConfirmRequest": {
-        "additionalProperties": false,
-        "description": "Trento User totp enrollment confirmation payload",
-        "properties": {
-          "totp_code": {
-            "description": "TOTP generated from enrollment secret",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["totp_code"],
-        "title": "UserTOTPEnrollmentConfirmRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Pagination": {
-        "additionalProperties": false,
-        "description": "Pagination metadata for the current list.",
-        "properties": {
-          "end_cursor": {
-            "description": "Cursor pointing to the end of the list.",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "first": {
-            "description": "Number of elements requested from the beginning of the list (forward navigation).",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "has_next_page": {
-            "description": "Flag indicating if there are more pages after the current one.",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "has_previous_page": {
-            "description": "Flag indicating if there are more pages before the current one.",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "last": {
-            "description": "Number of elements requested from the end of the list (backward navigation).",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "start_cursor": {
-            "description": "Cursor pointing to the start of the list.",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           }
         },
         "required": [
-          "start_cursor",
-          "end_cursor",
-          "has_next_page",
-          "has_previous_page",
-          "first",
-          "last"
+          "execution_id",
+          "group_id",
+          "targets"
         ],
-        "title": "Pagination",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "title": "StartExecutionRequest",
+        "type": "object"
       },
-      "Ready": {
+      "1.5.0_v1_StepReport": {
         "additionalProperties": false,
+        "description": "Represents a report for a single step in an operation, including step details and agent outcomes.",
         "example": {
-          "ready": true
+          "agents": [
+            {
+              "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+              "diff": {
+                "after": "present",
+                "before": "absent"
+              },
+              "error_message": "",
+              "result": "updated"
+            }
+          ],
+          "name": "install_package",
+          "operator": "equals",
+          "predicate": "package_installed == true",
+          "timeout": 60
         },
         "properties": {
-          "ready": {
-            "description": "Trento Web platform ready",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
+          "agents": {
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v1_AgentReport"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "The name of the operation step being reported.",
+            "type": "string"
+          },
+          "operator": {
+            "description": "The operator used in the operation step, specifying the comparison or action performed.",
+            "type": "string"
+          },
+          "predicate": {
+            "description": "The predicate evaluated in the operation step, defining the condition for success.",
+            "type": "string"
+          },
+          "timeout": {
+            "description": "The timeout value for the operation step, specifying the maximum allowed duration in seconds.",
+            "type": "integer"
           }
         },
-        "title": "Ready",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "required": [
+          "name",
+          "operator",
+          "predicate",
+          "timeout",
+          "agents"
+        ],
+        "title": "StepReport",
+        "type": "object"
       },
-      "SbdDevice": {
+      "1.5.0_v1_Target": {
         "additionalProperties": false,
-        "description": "SBD Device",
-        "properties": {
-          "device": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "status": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "SbdDevice",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "RelevantPatch": {
-        "additionalProperties": false,
-        "description": "Relevant patch",
-        "properties": {
-          "advisory_name": {
-            "description": "Advisory name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "advisory_status": {
-            "description": "Advisory status",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "advisory_synopsis": {
-            "description": "Advisory's synopsis",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "advisory_type": {
-            "description": "Advisory's type",
-            "enum": ["security_advisory", "bugfix", "enhancement"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "date": {
-            "description": "Advisory's date",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "Advisory's id",
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "update_date": {
-            "description": "Advisory's update date",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "RelevantPatch",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Credentials": {
+        "description": "Represents the target where execution facts are gathered, including agent and check associations.",
         "example": {
-          "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A",
-          "expires_in": 600,
-          "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A"
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "checks": [
+            "SLES-HA-1"
+          ]
         },
         "properties": {
-          "access_token": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "agent_id": {
+            "description": "The unique identifier of the agent for which facts are gathered during execution.",
+            "format": "uuid",
+            "type": "string"
           },
-          "expires_in": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "refresh_token": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "checks": {
+            "items": {
+              "description": "The unique identifier of the check associated with the target agent for execution.",
+              "type": "string"
+            },
+            "type": "array"
           }
         },
-        "title": "Credentials",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "required": [
+          "agent_id",
+          "checks"
+        ],
+        "title": "Target",
+        "type": "object"
       },
-      "BadRequest": {
+      "1.5.0_v1_UnprocessableEntity": {
         "additionalProperties": false,
+        "description": "This response indicates that the request could not be processed due to semantic errors or invalid data.",
+        "example": {
+          "errors": [
+            {
+              "detail": "null value where string expected",
+              "title": "Invalid value"
+            }
+          ]
+        },
         "properties": {
           "errors": {
+            "example": [
+              {
+                "detail": "null value where string expected",
+                "title": "Invalid value"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "example": "null value where string expected",
+                  "type": "string"
+                },
+                "title": {
+                  "example": "Invalid value",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "detail"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "errors"
+        ],
+        "title": "UnprocessableEntity",
+        "type": "object"
+      },
+      "1.5.0_v1_Value": {
+        "additionalProperties": false,
+        "description": "Represents a value used in the expectations evaluation, including its name, check association, and customization status.",
+        "example": {
+          "check_id": "SLES-HA-1",
+          "customized": false,
+          "name": "fencing_configured",
+          "value": true
+        },
+        "properties": {
+          "check_id": {
+            "description": "The unique identifier of the check associated with the value.",
+            "type": "string"
+          },
+          "customized": {
+            "description": "Indicates whether the value has been customized for the expectations evaluation.",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The name of the value used in the expectations evaluation.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value used in the expectations evaluation, which may be a string, integer, boolean, or array.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          }
+        },
+        "required": [
+          "check_id",
+          "name",
+          "value"
+        ],
+        "title": "Value",
+        "type": "object"
+      },
+      "1.5.0_v2_AcceptedExecutionResponse": {
+        "additionalProperties": false,
+        "description": "This response contains the identifiers for an execution that was recently accepted by the system. These identifiers can be used to query the execution status later.",
+        "example": {
+          "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+          "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79"
+        },
+        "properties": {
+          "execution_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "group_id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "title": "AcceptedExecutionResponse",
+        "type": "object"
+      },
+      "1.5.0_v2_AgentCheckError": {
+        "additionalProperties": false,
+        "description": "Indicates that some facts could not be gathered on a specific agent due to issues such as gathering failure or timeout. This error provides context for troubleshooting agent data collection problems.",
+        "example": {
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "facts": [
+            {
+              "check_id": "SLES-HA-1",
+              "name": "node_count",
+              "value": 3
+            },
+            {
+              "check_id": "SLES-HA-1",
+              "message": "Timeout",
+              "name": "node_count",
+              "type": "gathering_error"
+            }
+          ],
+          "message": "Timeout while gathering facts",
+          "type": "gathering_error"
+        },
+        "properties": {
+          "agent_id": {
+            "description": "The unique identifier of the agent involved in the error.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "facts": {
+            "description": "Facts gathered from the target agent, which may include errors encountered during the data collection process.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/1.5.0_v2_Fact"
+                },
+                {
+                  "$ref": "#/components/schemas/1.5.0_v2_FactError"
+                }
+              ]
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "message": {
+            "description": "A detailed message describing the error encountered during fact gathering on the agent.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of error encountered during fact gathering on the agent.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent_id",
+          "type",
+          "message"
+        ],
+        "title": "AgentCheckError",
+        "type": "object"
+      },
+      "1.5.0_v2_AgentCheckResult": {
+        "description": "Represents the result of a check performed on a specific agent, including gathered facts and expectation evaluations.",
+        "example": {
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "expectation_evaluations": [
+            {
+              "name": "fencing_enabled",
+              "return_value": true,
+              "type": "expect"
+            }
+          ],
+          "facts": [
+            {
+              "check_id": "SLES-HA-1",
+              "name": "node_count",
+              "value": 3
+            }
+          ],
+          "values": [
+            {
+              "check_id": "SLES-HA-1",
+              "customized": false,
+              "name": "fencing_configured",
+              "value": true
+            }
+          ]
+        },
+        "properties": {
+          "agent_id": {
+            "description": "The unique identifier of the agent for which the check was performed.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "expectation_evaluations": {
+            "description": "Result of the single expectation evaluation, indicating whether the expectation was met for the agent's check.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/1.5.0_v2_ExpectationEvaluation"
+                },
+                {
+                  "$ref": "#/components/schemas/1.5.0_v2_ExpectationEvaluationError"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "facts": {
+            "description": "Facts gathered from the target agent during the check execution.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v2_Fact"
+            },
+            "type": "array"
+          },
+          "values": {
+            "description": "Values resolved for the current execution, representing the computed results for the agent's check.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v2_Value"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "agent_id",
+          "facts",
+          "expectation_evaluations"
+        ],
+        "title": "AgentCheckResult",
+        "type": "object"
+      },
+      "1.5.0_v2_BadRequest": {
+        "additionalProperties": false,
+        "description": "This response indicates that the request was malformed or contained invalid parameters, and could not be processed.",
+        "example": {
+          "errors": [
+            {
+              "detail": "Invalid request payload.",
+              "title": "Bad Request"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
+              {
+                "detail": "Invalid request payload.",
+                "title": "Bad Request"
+              }
+            ],
             "items": {
               "properties": {
                 "detail": {
                   "example": "Invalid request payload.",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "type": "string"
                 },
                 "title": {
                   "example": "Bad Request",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "type": "string"
                 }
               },
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
+              "type": "object"
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           }
         },
         "title": "BadRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "type": "object"
       },
-      "SlesSubscription": {
+      "1.5.0_v2_CatalogResponse": {
         "additionalProperties": false,
-        "description": "A discovered SLES Subscription on a host",
+        "description": "Represents the response for a catalog listing, including a list of catalog checks and their details.",
+        "example": {
+          "items": [
+            {
+              "description": "Verifies whether fencing is configured for all nodes in the cluster to ensure high availability, providing context for remediation.",
+              "expectations": [
+                {
+                  "expression": "fencing_configured == true",
+                  "failure_message": "Fencing is not configured for all nodes.",
+                  "name": "fencing_enabled",
+                  "type": "expect"
+                }
+              ],
+              "facts": [
+                {
+                  "argument": "",
+                  "gatherer": "cluster_node_gatherer",
+                  "name": "node_count"
+                }
+              ],
+              "group": "SLES-HA",
+              "id": "SLES-HA-1",
+              "metadata": {
+                "category": "ha",
+                "impact": "critical"
+              },
+              "name": "Cluster node fencing configured",
+              "premium": false,
+              "remediation": "Configure fencing for all cluster nodes to ensure high availability.",
+              "severity": "critical",
+              "values": [
+                {
+                  "conditions": [
+                    {
+                      "expression": "node_count > 1",
+                      "value": true
+                    }
+                  ],
+                  "default": false,
+                  "name": "fencing_configured"
+                }
+              ],
+              "when": "node_count > 0"
+            }
+          ]
+        },
         "properties": {
-          "arch": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "items": {
+            "description": "A list of catalog checks included in the response, each with metadata and configuration options.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v2_Check"
+            },
+            "type": "array"
+          }
+        },
+        "title": "CatalogResponse",
+        "type": "object"
+      },
+      "1.5.0_v2_Check": {
+        "additionalProperties": false,
+        "description": "Represents a single check from the catalog, including its metadata, configuration, and validation logic.",
+        "example": {
+          "description": "Checks if fencing is configured for all cluster nodes.",
+          "expectations": [
+            {
+              "expression": "fencing_configured == true",
+              "failure_message": "Fencing is not configured for all nodes.",
+              "name": "fencing_enabled",
+              "type": "expect"
+            }
+          ],
+          "facts": [
+            {
+              "argument": "",
+              "gatherer": "cluster_node_gatherer",
+              "name": "node_count"
+            }
+          ],
+          "group": "SLES-HA",
+          "id": "SLES-HA-1",
+          "metadata": {
+            "category": "ha",
+            "impact": "critical"
           },
-          "expires_at": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "name": "Cluster node fencing configured",
+          "premium": false,
+          "remediation": "Configure fencing for all cluster nodes to ensure high availability.",
+          "severity": "critical",
+          "values": [
+            {
+              "conditions": [
+                {
+                  "expression": "node_count > 1",
+                  "value": true
+                }
+              ],
+              "default": false,
+              "name": "fencing_configured"
+            }
+          ],
+          "when": "node_count > 0"
+        },
+        "properties": {
+          "description": {
+            "description": "A description of the check, outlining its purpose and expected behavior.",
+            "type": "string"
           },
-          "host_id": {
+          "expectations": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "expression": {
+                  "description": "The expression to be evaluated to get the expectation result for the check.",
+                  "type": "string"
+                },
+                "failure_message": {
+                  "description": "A message returned when the check fails, providing context for troubleshooting.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the expectation for the check.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "The type of expectation for the check, such as expect or expect_same.",
+                  "enum": [
+                    "unknown",
+                    "expect",
+                    "expect_same"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type",
+                "expression",
+                "failure_message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "facts": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "argument": {
+                  "description": "The argument provided to the gatherer for fact collection.",
+                  "type": "string"
+                },
+                "gatherer": {
+                  "description": "The gatherer used to collect the fact for the check.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the fact gathered for the check.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "gatherer",
+                "argument"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "group": {
+            "description": "The group to which the check belongs, providing logical organization.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique identifier of the check in the catalog.",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Metadata associated with the check, providing additional context and categorization.",
+            "nullable": true,
+            "type": "object"
+          },
+          "name": {
+            "description": "The name of the check in the catalog, used for identification and reporting.",
+            "type": "string"
+          },
+          "premium": {
+            "deprecated": true,
+            "description": "Check is Premium or not",
+            "type": "boolean"
+          },
+          "remediation": {
+            "description": "A remediation message for the check, providing guidance on resolving issues detected.",
+            "type": "string"
+          },
+          "severity": {
+            "description": "The severity of the check, such as critical or warning, indicating its impact.",
+            "enum": [
+              "critical",
+              "warning"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "expression": {
+                        "description": "The expression to be evaluated to use the current value for the check.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The value to be used for this condition in the check.",
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "expression"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "default": {
+                  "description": "The default value used if none of the conditions matches for the check.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                },
+                "name": {
+                  "description": "The name of the value used in the check.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "default",
+                "conditions"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "when": {
+            "description": "An expression to determine whether a check should run, allowing for conditional execution.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "group",
+          "description",
+          "remediation",
+          "metadata",
+          "severity",
+          "facts",
+          "values",
+          "expectations",
+          "when",
+          "premium"
+        ],
+        "title": "Check",
+        "type": "object"
+      },
+      "1.5.0_v2_CheckResult": {
+        "additionalProperties": false,
+        "description": "This object represents the result of a check execution, including expectation evaluations and agent-specific results.",
+        "example": {
+          "agents_check_results": [],
+          "check_id": "SLES-HA-1",
+          "customized": false,
+          "expectation_results": [
+            {
+              "failure_message": "Fencing is not configured for all nodes.",
+              "name": "fencing_enabled",
+              "result": true,
+              "type": "expect"
+            }
+          ],
+          "result": "critical"
+        },
+        "properties": {
+          "agents_check_results": {
+            "description": "An array containing the results of the check execution for each agent, including any errors encountered.",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/1.5.0_v2_AgentCheckResult"
+                },
+                {
+                  "$ref": "#/components/schemas/1.5.0_v2_AgentCheckError"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "check_id": {
+            "description": "A unique identifier for the check that was executed.",
+            "type": "string"
+          },
+          "customized": {
+            "description": "Specifies if the check was customized for this particular execution instance.",
+            "type": "boolean"
+          },
+          "expectation_results": {
+            "description": "An array containing the results of each expectation evaluated during the check execution.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v2_ExpectationResult"
+            },
+            "type": "array"
+          },
+          "result": {
+            "description": "The overall result of the check execution, which may be passing, warning, or critical.",
+            "enum": [
+              "passing",
+              "warning",
+              "critical"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "check_id",
+          "expectation_results",
+          "agents_check_results",
+          "result"
+        ],
+        "title": "CheckResult",
+        "type": "object"
+      },
+      "1.5.0_v2_ExecutionEnv": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/components/schemas/1.5.0_v2_ExecutionEnv"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "description": "Defines the contextual environment settings used during the current execution, allowing for flexible configuration.",
+        "example": {
+          "DEBUG": true,
+          "MAX_RETRIES": 3,
+          "VAR1": "value1"
+        },
+        "title": "ExecutionEnv",
+        "type": "object"
+      },
+      "1.5.0_v2_ExecutionResponse": {
+        "additionalProperties": false,
+        "description": "This object represents the details and status of an execution, which may be running or completed.",
+        "example": {
+          "check_results": [
+            {
+              "agents_check_results": [],
+              "check_id": "SLES-HA-1",
+              "customized": false,
+              "expectation_results": [
+                {
+                  "failure_message": "Fencing is not configured for all nodes.",
+                  "name": "fencing_enabled",
+                  "result": true,
+                  "type": "expect"
+                }
+              ],
+              "result": "critical"
+            }
+          ],
+          "completed_at": "2025-08-04T10:05:00Z",
+          "critical_count": 1,
+          "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+          "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+          "passing_count": 0,
+          "result": "critical",
+          "started_at": "2025-08-04T10:00:00Z",
+          "status": "completed",
+          "targets": [
+            {
+              "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+              "checks": [
+                "SLES-HA-1"
+              ]
+            }
+          ],
+          "timeout": [],
+          "warning_count": 0
+        },
+        "properties": {
+          "check_results": {
+            "description": "An array containing the results of each check performed during the execution.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v2_CheckResult"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "completed_at": {
+            "description": "The timestamp when the execution was completed, if available.",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "critical_count": {
+            "description": "The number of checks that resulted in a critical status during the execution.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "execution_id": {
+            "description": "A unique identifier for the execution instance.",
             "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "type": "string"
           },
-          "identifier": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "group_id": {
+            "description": "A unique identifier for the group associated with this execution instance.",
+            "format": "uuid",
+            "type": "string"
           },
-          "starts_at": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "passing_count": {
+            "description": "The number of checks that resulted in a passing status during the execution.",
+            "nullable": true,
+            "type": "integer"
+          },
+          "result": {
+            "description": "The overall result of the execution, which may be unknown if the execution is still running.",
+            "enum": [
+              "passing",
+              "warning",
+              "critical"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "started_at": {
+            "description": "The timestamp when the execution started.",
+            "format": "date-time",
+            "type": "string"
           },
           "status": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "subscription_status": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "type": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "version": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "SlesSubscription",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UnprocessableEntity": {
-        "additionalProperties": false,
-        "properties": {
-          "errors": {
-            "items": {
-              "properties": {
-                "detail": {
-                  "example": "null value where string expected",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "title": {
-                  "example": "Invalid value",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "required": ["title", "detail"],
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["errors"],
-        "title": "UnprocessableEntity",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "IPv4": {
-        "format": "ipv4",
-        "title": "IPv4",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ApplicationInstance": {
-        "additionalProperties": false,
-        "description": "A discovered Application Instance on the target infrastructure",
-        "properties": {
-          "absent_at": {
-            "description": "Absent instance timestamp",
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "features": {
-            "description": "Instance Features",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "health": {
-            "$ref": "#/components/schemas/ResourceHealth"
-          },
-          "host_id": {
-            "description": "Identifier of the host where current instance is running",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "http_port": {
-            "description": "Instance HTTP Port",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "https_port": {
-            "description": "Instance HTTPS Port",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "inserted_at": {
-            "format": "datetime",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "instance_hostname": {
-            "description": "Instance Hostname",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "instance_number": {
-            "description": "Instance Number",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sap_system_id": {
-            "description": "SAP System ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sid": {
-            "description": "SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "start_priority": {
-            "description": "Instance Start Priority",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "ApplicationInstance",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "EnabledNotes": {
-        "description": "A list of enabled notes",
-        "items": {
-          "$ref": "#/components/schemas/SaptuneNote"
-        },
-        "title": "Enabled notes",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ClusterMaintenanceChangeParams": {
-        "additionalProperties": false,
-        "description": "Cluster maintenance change operation params. If neither resource_id nor node_id are given the complete cluster maintenance state is changed. resource_id has precedence over node_id",
-        "properties": {
-          "maintenance": {
-            "description": "Maintenance state to put the cluster/node/resource",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "node_id": {
-            "description": "ID of the cluster node to change the maintenance state",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "resource_id": {
-            "description": "ID of the cluster resource to change the maintenance state",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["maintenance"],
-        "title": "ClusterMaintenanceChangeParams",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserCollection": {
-        "description": "A collection of users in the system",
-        "items": {
-          "$ref": "#/components/schemas/UserItem"
-        },
-        "title": "UserCollection",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ActivityLogEntries": {
-        "items": {
-          "additionalProperties": false,
-          "properties": {
-            "actor": {
-              "description": "Actor causing an Activity Log entry. E.g. System or a specific user.",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "id": {
-              "description": "UUID (v4) of Activity Log entry.",
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "metadata": {
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "occurred_on": {
-              "description": "Timestamp upon Activity Log entry insertion.",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "severity": {
-              "description": "Severity level of an Activity Log entry. E.g. info, warning etc.",
-              "enum": ["debug", "info", "warning", "error", "critical"],
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": {
-              "description": "Type of Activity Log entry.",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          "required": ["id", "type", "actor", "metadata", "occurred_on"],
-          "title": "ActivityLogEntries",
-          "type": "object",
-          "x-struct": null,
-          "x-validate": null
-        },
-        "title": "ActivityLogEntries",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Host": {
-        "additionalProperties": false,
-        "description": "A discovered host on the target infrastructure",
-        "properties": {
-          "agent_version": {
-            "description": "Version of the agent installed on the host",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "cluster_id": {
-            "description": "Identifier of the cluster this host is part of",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "deregistered_at": {
-            "description": "Timestamp of the last deregistration of the host",
-            "format": "date-time",
-            "nullable": true,
-            "title": "DeregisteredAt",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "health": {
-            "$ref": "#/components/schemas/ResourceHealth"
-          },
-          "heartbeat": {
-            "description": "Host's last heartbeat status",
-            "enum": ["critical", "passing", "unknown"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "hostname": {
-            "description": "Host name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "Host ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "inserted_at": {
-            "format": "datetime",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "ip_addresses": {
-            "description": "IP addresses",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/IPv4"
-                },
-                {
-                  "$ref": "#/components/schemas/IPv6"
-                }
-              ],
-              "title": "IPAddress",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "last_heartbeat_timestamp": {
-            "description": "Timestamp of the last heartbeat received from the host",
-            "format": "date-time",
-            "nullable": true,
-            "title": "LastHeartbeatTimestamp",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "netmasks": {
-            "description": "Netmasks associated to the ip_addresses field. The position of the item is associated to the ip address position in ip_addresses",
-            "items": {
-              "nullable": true,
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "provider": {
-            "$ref": "#/components/schemas/SupportedProviders"
-          },
-          "provider_data": {
-            "$ref": "#/components/schemas/ProviderMetadata"
-          },
-          "saptune_status": {
-            "$ref": "#/components/schemas/SaptuneStatus"
-          },
-          "selected_checks": {
-            "description": "A list of check ids selected for an execution on this host",
-            "items": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "title": "SelectedChecks",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sles_subscriptions": {
-            "description": "A list of the available SLES Subscriptions on a host",
-            "items": {
-              "$ref": "#/components/schemas/SlesSubscription"
-            },
-            "title": "SlesSubscriptions",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "tags": {
-            "$ref": "#/components/schemas/Tags"
-          },
-          "updated_at": {
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Host",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SelectedChecks": {
-        "description": "A list of check ids selected for an execution on this cluster",
-        "items": {
-          "type": "string",
-          "x-struct": null,
-          "x-validate": null
-        },
-        "title": "SelectedChecks",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Hostname": {
-        "format": "hostname",
-        "title": "Hostname",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Tag": {
-        "additionalProperties": false,
-        "description": "A tag attached to a resource",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "inserted_at": {
-            "format": "datetime",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "resource_id": {
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "resource_type": {
-            "enum": ["host", "cluster", "sap_system", "database"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "value": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Tag",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SapInstanceOperationParams": {
-        "type": "object",
-        "description": "SAP instance operation request parameters",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/StartStopParams"
-          }
-        ],
-        "title": "SapInstanceOperationParams",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UpdateSuseManagerSettingsRequest": {
-        "additionalProperties": false,
-        "description": "Request body for updating SUMA settings.\nOnly provide fields to be updated",
-        "minProperties": 1,
-        "properties": {
-          "ca_cert": {
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "url": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "UpdateSuseManagerSettingsRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "RefreshCredentials": {
-        "example": {
-          "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJ1c2VyX2lkIjoxfQ.frHteBttgtW8706m7nqYC6ruYtTrbVcCEO_UgIkHn6A"
-        },
-        "properties": {
-          "refresh_token": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Refresh Credentials",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "OperationAccepted": {
-        "additionalProperties": false,
-        "description": "The operation has been authorized and requested",
-        "properties": {
-          "operation_id": {
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["operation_id"],
-        "title": "OperationAccepted",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "TrentoUser": {
-        "example": {
-          "id": 1,
-          "username": "admin"
-        },
-        "properties": {
-          "id": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "TrentoUser",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "IPAddress": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/IPv4"
-          },
-          {
-            "$ref": "#/components/schemas/IPv6"
-          }
-        ],
-        "title": "IPAddress",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AwsProviderData": {
-        "additionalProperties": false,
-        "description": "AWS detected metadata",
-        "properties": {
-          "account_id": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "ami_id": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "availability_zone": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "data_disk_number": {
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "instance_id": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "instance_type": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "region": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "vpc_id": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "AwsProviderData",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AffectedPackage": {
-        "description": "Metadata for a package effected by an advisory",
-        "properties": {
-          "arch_label": {
-            "description": "Package architecture",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "epoch": {
-            "description": "Package epoch number",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Package name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "release": {
-            "description": "Package RPM release number",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "version": {
-            "description": "Package upstream version",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "AffectedPackage",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "DatabaseInstance": {
-        "additionalProperties": false,
-        "description": "A discovered HANA Database Instance on the target infrastructure",
-        "properties": {
-          "absent_at": {
-            "description": "Absent instance timestamp",
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "database_id": {
-            "description": "Database ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "features": {
-            "description": "Instance Features",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "health": {
-            "$ref": "#/components/schemas/ResourceHealth"
-          },
-          "host_id": {
-            "description": "Identifier of the host where current instance is running",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "http_port": {
-            "description": "Instance HTTP Port",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "https_port": {
-            "description": "Instance HTTPS Port",
-            "nullable": true,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "inserted_at": {
-            "format": "datetime",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "instance_hostname": {
-            "description": "Instance Hostname",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "instance_number": {
-            "description": "Instance Number",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sap_system_id": {
-            "deprecated": true,
-            "description": "SAP System ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sid": {
-            "description": "SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "start_priority": {
-            "description": "Instance Start Priority",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "system_replication": {
-            "description": "System Replication",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "system_replication_status": {
-            "description": "System Replication Status",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "tenant": {
-            "description": "Tenant",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "DatabaseInstance",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AffectedSystems": {
-        "additionalProperties": false,
-        "description": "Response returned from the get affected systems endpoint",
-        "items": {
-          "description": "Metadata for a system effected by an advisory",
-          "properties": {
-            "name": {
-              "description": "System name",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          "title": "AffectedSystem",
-          "type": "object",
-          "x-struct": null,
-          "x-validate": null
-        },
-        "title": "AffectedSystems",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserTOTPEnrollmentConfirmPayload": {
-        "additionalProperties": false,
-        "description": "Trento User TOTP enrollment completed payload",
-        "properties": {
-          "totp_enabled_at": {
-            "description": "Date of TOTP enrollment",
-            "format": "date-time",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["totp_enabled_at"],
-        "title": "UserTOTPEnrollmentConfirmPayload",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HanaClusterDetails": {
-        "additionalProperties": false,
-        "description": "Details of a HANA Pacemaker Cluster",
-        "properties": {
-          "fencing_type": {
-            "description": "Fencing Type",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/HanaClusterNode"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sbd_devices": {
-            "items": {
-              "$ref": "#/components/schemas/SbdDevice"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "secondary_sync_state": {
-            "description": "Secondary Sync State",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sr_health_state": {
-            "description": "SR health state",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "stopped_resources": {
-            "description": "A list of the stopped resources on this HANA Cluster",
-            "items": {
-              "$ref": "#/components/schemas/ClusterResource"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "system_replication_mode": {
-            "description": "System Replication Mode",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "system_replication_operation_mode": {
-            "description": "System Replication Operation Mode",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["nodes"],
-        "title": "HanaClusterDetails",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaptuneServices": {
-        "description": "A list of saptune services",
-        "items": {
-          "$ref": "#/components/schemas/SaptuneService"
-        },
-        "title": "Saptune services",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaptuneStaging": {
-        "additionalProperties": false,
-        "description": "Saptune staging data",
-        "properties": {
-          "enabled": {
-            "description": "Saptune staging is enabled",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "notes": {
-            "description": "Staged saptune note IDs",
-            "items": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "solutions_ids": {
-            "description": "Staged saptune solution IDs",
-            "items": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Saptune staging",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AdvisoryFixes": {
-        "additionalProperties": {
-          "type": "string",
-          "x-struct": null,
-          "x-validate": null
-        },
-        "description": "Response returned from the get advisory fixes endpoint",
-        "title": "AdvisoryFixes",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ErrataDetails": {
-        "additionalProperties": false,
-        "description": "Details for the erratum matching the given advisory name",
-        "properties": {
-          "advisory_status": {
-            "description": "Advisory status",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "description": {
-            "description": "Advisory description",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "errata_from": {
-            "description": "Advisory errata",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "Advisory ID number",
-            "type": "number",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "issue_date": {
-            "description": "Advisory issue date",
-            "format": "date",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "last_modified_date": {
-            "description": "Advisory last modified date",
-            "format": "date",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "notes": {
-            "description": "Advisory notes",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "product": {
-            "description": "Advisory product",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "reboot_suggested": {
-            "description": "A boolean flag signaling whether a system reboot is advisable following the application of the errata. Typical example is upon kernel update.",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "references": {
-            "description": "Advisory references",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "release": {
-            "description": "Advisory Release number",
-            "type": "number",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "restart_suggested": {
-            "description": "A boolean flag signaling a weather reboot of the package manager is advisable following the application of the errata. This is commonly used to address update stack issues before proceeding with other updates.",
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "solution": {
-            "description": "Advisory solution",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "synopsis": {
-            "description": "Advisory synopsis",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "topic": {
-            "description": "Advisory topic",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "type": {
-            "description": "Advisory type",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "update_date": {
-            "description": "Advisory update date",
-            "format": "date",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "vendor_advisory": {
-            "description": "Vendor advisory",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "ErrataDetails",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "DiscoveryEvent": {
-        "additionalProperties": false,
-        "description": "A discovery event",
-        "properties": {
-          "agent_id": {
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "discovery_type": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "payload": {
-            "nullable": true,
-            "oneOf": [
-              {
-                "type": "object",
-                "x-struct": null,
-                "x-validate": null
-              },
-              {
-                "type": "array",
-                "x-struct": null,
-                "x-validate": null,
-                "items": {
-                  "type": "object",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              }
+            "description": "Indicates whether the execution is currently running or has been completed.",
+            "enum": [
+              "running",
+              "completed"
             ],
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["agent_id", "discovery_type", "payload"],
-        "title": "DiscoveryEvent",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ApiKeySettingsUpdateRequest": {
-        "additionalProperties": false,
-        "description": "Request body for api key settings update",
-        "properties": {
-          "expire_at": {
-            "description": "The expire date of api key",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["expire_at"],
-        "title": "ApiKeySettingsUpdateRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AbilityCollection": {
-        "description": "A collection of abilities in the system",
-        "items": {
-          "$ref": "#/components/schemas/Ability"
-        },
-        "title": "AbilityCollection",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Ability": {
-        "additionalProperties": false,
-        "description": "Ability entry",
-        "properties": {
-          "id": {
-            "description": "Ability ID",
-            "nullable": false,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "label": {
-            "description": "Description of the ability",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Ability name",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "resource": {
-            "description": "Resource attached to ability",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["id", "name", "resource"],
-        "title": "Ability",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "RetentionTimeSettings": {
-        "additionalProperties": false,
-        "description": "Retention Time settings of the Activity Log",
-        "properties": {
-          "unit": {
-            "description": "The retention duration unit, that is used in conjunction with the retention time period.",
-            "enum": ["day", "week", "month", "year"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "value": {
-            "description": "The integer retention duration, that is used in conjunction with the retention time unit.",
-            "minimum": 1,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["value", "unit"],
-        "title": "RetentionTimeSettings",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Database": {
-        "additionalProperties": false,
-        "description": "A discovered HANA Database on the target infrastructure",
-        "properties": {
-          "database_instances": {
-            "$ref": "#/components/schemas/DatabaseInstances"
-          },
-          "health": {
-            "$ref": "#/components/schemas/ResourceHealth"
-          },
-          "id": {
-            "description": "Database ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "inserted_at": {
-            "format": "datetime",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sid": {
-            "description": "SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "tags": {
-            "$ref": "#/components/schemas/Tags"
-          },
-          "updated_at": {
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Database",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserProfile": {
-        "additionalProperties": false,
-        "description": "Trento User profile",
-        "properties": {
-          "abilities": {
-            "$ref": "#/components/schemas/AbilityCollection"
-          },
-          "analytics_enabled": {
-            "description": "Whether user analytics collection is enabled",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "created_at": {
-            "description": "Date of user creation",
-            "format": "date-time",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "email": {
-            "description": "User email",
-            "format": "email",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "fullname": {
-            "description": "User full name",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "id": {
-            "description": "User ID",
-            "nullable": false,
-            "type": "integer",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "idp_user": {
-            "description": "User coming from an external IDP",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password_change_requested": {
-            "description": "Password change is requested",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "totp_enabled": {
-            "description": "TOTP is enabled",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "description": "Date of user last update",
-            "format": "date-time",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "description": "User username",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": [
-          "username",
-          "id",
-          "fullname",
-          "email",
-          "created_at",
-          "totp_enabled"
-        ],
-        "title": "UserProfile",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PreconditionRequired": {
-        "additionalProperties": false,
-        "properties": {
-          "errors": {
-            "items": {
-              "properties": {
-                "detail": {
-                  "example": "Request needs to be conditional, please provide If-Match header.",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "title": {
-                  "example": "Precondition Required",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                }
-              },
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "PreconditionRequired",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SupportedProviders": {
-        "description": "Detected Provider where the resource is running",
-        "enum": ["azure", "aws", "gcp", "kvm", "nutanix", "vmware", "unknown"],
-        "title": "SupportedProviders",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaptuneService": {
-        "additionalProperties": false,
-        "description": "Saptune service",
-        "properties": {
-          "active": {
-            "description": "Active state as string",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "enabled": {
-            "description": "Enabled state as string",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "description": "Saptune service name",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Saptune service",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HanaClusterNode": {
-        "additionalProperties": false,
-        "description": "A HANA Cluster Node",
-        "properties": {
-          "attributes": {
-            "additionalProperties": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "description": "Node attributes",
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "hana_status": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "name": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "resources": {
-            "description": "A list of Cluster resources",
-            "items": {
-              "$ref": "#/components/schemas/ClusterResource"
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "site": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "virtual_ip": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "HanaClusterNode",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "AppliedNotes": {
-        "description": "A list of applied notes",
-        "items": {
-          "$ref": "#/components/schemas/SaptuneNote"
-        },
-        "title": "Applied notes",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HostOperationParams": {
-        "type": "object",
-        "description": "Host operation request parameters",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/SaptuneSolutionApplyParams"
-          }
-        ],
-        "title": "HostOperationParams",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "Targets": {
-        "anyOf": [
-          {
-            "format": "ipv6",
-            "title": "IPv6",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          {
-            "format": "ipv4",
-            "title": "IPv4",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          {
-            "format": "hostname",
-            "title": "Hostname",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        ],
-        "title": "Targets",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserCreationRequest": {
-        "additionalProperties": false,
-        "description": "Request body to create a user",
-        "properties": {
-          "abilities": {
-            "$ref": "#/components/schemas/AbilityCollection"
-          },
-          "email": {
-            "description": "User email",
-            "format": "email",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "enabled": {
-            "description": "User enabled in the system",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "fullname": {
-            "description": "User full name",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password": {
-            "description": "User new password",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password_confirmation": {
-            "description": "User new password, should be the same as password field",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "description": "User username",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": [
-          "fullname",
-          "email",
-          "enabled",
-          "password",
-          "password_confirmation",
-          "username"
-        ],
-        "title": "UserCreationRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SAPSystem": {
-        "additionalProperties": false,
-        "description": "A discovered SAP System on the target infrastructure",
-        "properties": {
-          "application_instances": {
-            "description": "A list of the discovered Application Instances for current SAP Systems",
-            "items": {
-              "$ref": "#/components/schemas/ApplicationInstance"
-            },
-            "title": "ApplicationInstances",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "database_id": {
-            "description": "Database ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "database_instances": {
-            "$ref": "#/components/schemas/DatabaseInstances"
-          },
-          "database_sid": {
-            "description": "Database SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "db_host": {
-            "description": "Address of the connected Database",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "ensa_version": {
-            "description": "ENSA version of the SAP system",
-            "enum": ["no_ensa", "ensa1", "ensa2"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "health": {
-            "$ref": "#/components/schemas/ResourceHealth"
-          },
-          "id": {
-            "description": "SAP System ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "inserted_at": {
-            "format": "datetime",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "sid": {
-            "description": "SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "tags": {
-            "$ref": "#/components/schemas/Tags"
-          },
-          "tenant": {
-            "description": "Tenant",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "updated_at": {
-            "format": "datetime",
-            "nullable": true,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "SAPSystem",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ApiKey": {
-        "properties": {
-          "api_key": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "ApiKey",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HttpStd": {
-        "additionalProperties": false,
-        "example": {
-          "labels": {
-            "labelname": "mylabel"
-          },
-          "targets": ["myhost.de"]
-        },
-        "properties": {
-          "labels": {
-            "additionalProperties": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "description": "String valued labels",
-            "type": "object",
-            "x-struct": null,
-            "x-validate": null
+            "type": "string"
           },
           "targets": {
-            "description": "List of targets",
+            "description": "An array of agents that participated in the execution process.",
             "items": {
-              "anyOf": [
-                {
-                  "format": "ipv6",
-                  "title": "IPv6",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+              "$ref": "#/components/schemas/1.5.0_v2_Target"
+            },
+            "type": "array"
+          },
+          "timeout": {
+            "description": "An array of agents that did not complete the execution within the expected time frame.",
+            "items": {
+              "description": "A unique identifier for the agent that timed out during execution.",
+              "format": "uuid",
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "warning_count": {
+            "description": "The number of checks that resulted in a warning status during the execution.",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "execution_id",
+          "group_id",
+          "status",
+          "started_at",
+          "completed_at",
+          "result",
+          "targets",
+          "critical_count",
+          "warning_count",
+          "passing_count",
+          "timeout",
+          "check_results"
+        ],
+        "title": "ExecutionResponse",
+        "type": "object"
+      },
+      "1.5.0_v2_ExpectationEvaluation": {
+        "additionalProperties": false,
+        "description": "Represents the result of evaluating an expectation, including its name, value, type, and any failure message.",
+        "example": {
+          "failure_message": "Fencing is not configured for all nodes.",
+          "name": "fencing_enabled",
+          "return_value": true,
+          "type": "expect"
+        },
+        "properties": {
+          "failure_message": {
+            "description": "A message describing the failure, only available for scenarios where the expectation was not met.",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the expectation being evaluated.",
+            "type": "string"
+          },
+          "return_value": {
+            "description": "The value returned from the expectation evaluation, indicating the outcome of the check.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "type": {
+            "description": "The type of evaluation performed for the expectation, such as expect or expect_same.",
+            "enum": [
+              "unknown",
+              "expect",
+              "expect_same"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "return_value",
+          "type"
+        ],
+        "title": "ExpectationEvaluation",
+        "type": "object"
+      },
+      "1.5.0_v2_ExpectationEvaluationError": {
+        "additionalProperties": false,
+        "description": "Indicates that an error occurred during the evaluation of an expectation, providing details for troubleshooting.",
+        "example": {
+          "message": "Expression evaluation failed.",
+          "name": "fencing_enabled",
+          "type": "evaluation_error"
+        },
+        "properties": {
+          "message": {
+            "description": "A detailed message describing the error encountered during expectation evaluation.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the expectation for which the error occurred.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of error encountered during expectation evaluation, such as validation or runtime error.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "message",
+          "type"
+        ],
+        "title": "ExpectationEvaluationError",
+        "type": "object"
+      },
+      "1.5.0_v2_ExpectationResult": {
+        "additionalProperties": false,
+        "description": "This object describes the outcome of an expectation evaluation during a check execution.",
+        "example": {
+          "failure_message": "Fencing is not configured for all nodes.",
+          "name": "fencing_enabled",
+          "result": true,
+          "type": "expect"
+        },
+        "properties": {
+          "failure_message": {
+            "description": "A message describing the reason for failure when the expectation is not met. Only available for certain scenarios.",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "A label that identifies the expectation being evaluated in the check.",
+            "type": "string"
+          },
+          "result": {
+            "description": "The outcome value produced by evaluating the expectation condition during the check execution.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "enum": [
+                  "passing",
+                  "warning",
+                  "critical"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": {
+            "description": "Specifies the type of evaluation performed for the expectation in the check execution.",
+            "enum": [
+              "unknown",
+              "expect",
+              "expect_same",
+              "expect_enum"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "result",
+          "type"
+        ],
+        "title": "ExpectationResult",
+        "type": "object"
+      },
+      "1.5.0_v2_Fact": {
+        "additionalProperties": false,
+        "description": "Represents a fact gathered during execution, including its check association and observed value.",
+        "example": {
+          "check_id": "SLES-HA-1",
+          "name": "node_count",
+          "value": 3
+        },
+        "properties": {
+          "check_id": {
+            "description": "The unique identifier of the check that produced this fact during execution.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the fact representing the observed property or metric gathered during execution.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The value of the fact as observed during execution, which may be a string, integer, boolean, or array.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "items": {
+                  "type": "string"
                 },
+                "type": "array"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "check_id",
+          "name",
+          "value"
+        ],
+        "title": "Fact",
+        "type": "object"
+      },
+      "1.5.0_v2_FactError": {
+        "additionalProperties": false,
+        "description": "Indicates that a fact could not be gathered during execution, providing details for troubleshooting data collection issues.",
+        "example": {
+          "check_id": "SLES-HA-1",
+          "message": "Timeout while gathering fact",
+          "name": "node_count",
+          "type": "gathering_error"
+        },
+        "properties": {
+          "check_id": {
+            "description": "The unique identifier of the check for which the fact could not be gathered.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A detailed message describing the error encountered during fact gathering.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the fact that could not be gathered during execution.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of error encountered during fact gathering.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "check_id",
+          "name",
+          "type",
+          "message"
+        ],
+        "title": "FactError",
+        "type": "object"
+      },
+      "1.5.0_v2_ListExecutionsResponse": {
+        "additionalProperties": false,
+        "description": "This schema represents a paginated response containing multiple execution records.",
+        "example": {
+          "items": [
+            {
+              "check_results": [
                 {
-                  "format": "ipv4",
-                  "title": "IPv4",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                {
-                  "format": "hostname",
-                  "title": "Hostname",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "agents_check_results": [],
+                  "check_id": "SLES-HA-1",
+                  "customized": false,
+                  "expectation_results": [
+                    {
+                      "failure_message": "Fencing is not configured for all nodes.",
+                      "name": "fencing_enabled",
+                      "result": true,
+                      "type": "expect"
+                    }
+                  ],
+                  "result": "critical"
                 }
               ],
-              "title": "Targets",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "HttpStd",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SlesSubscriptions": {
-        "description": "A list of the available SLES Subscriptions on a host",
-        "items": {
-          "$ref": "#/components/schemas/SlesSubscription"
-        },
-        "title": "SlesSubscriptions",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "LoginCredentials": {
-        "additionalProperties": false,
-        "example": {
-          "password": "thepassword",
-          "username": "admin"
-        },
-        "properties": {
-          "password": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "totp_code": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "username": {
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "LoginCredentials",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "UserUpdateRequest": {
-        "additionalProperties": false,
-        "description": "Request body to update a user",
-        "properties": {
-          "abilities": {
-            "$ref": "#/components/schemas/AbilityCollection"
-          },
-          "email": {
-            "description": "User email",
-            "format": "email",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "enabled": {
-            "description": "User enabled in the system",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "fullname": {
-            "description": "User full name",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password": {
-            "description": "User new password",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "password_confirmation": {
-            "description": "User new password, should be the same as password field",
-            "nullable": false,
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "totp_disabled": {
-            "description": "TOTP feature disabled for the user. The only accepted value here is 'true'",
-            "nullable": false,
-            "type": "boolean",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "UserUpdateRequest",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "PublicKeys": {
-        "description": "Uploaded public keys",
-        "items": {
-          "properties": {
-            "content": {
-              "description": "Public key content",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            },
-            "name": {
-              "description": "Name",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
+              "completed_at": "2025-08-04T10:05:00Z",
+              "critical_count": 1,
+              "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+              "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+              "passing_count": 0,
+              "result": "critical",
+              "started_at": "2025-08-04T10:00:00Z",
+              "status": "completed",
+              "targets": [
+                {
+                  "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+                  "checks": [
+                    "SLES-HA-1"
+                  ]
+                }
+              ],
+              "timeout": [],
+              "warning_count": 0
             }
-          },
-          "title": "PublicKey",
-          "type": "object",
-          "x-struct": null,
-          "x-validate": null
+          ],
+          "total_count": 1
         },
-        "title": "PublicKeys",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
+        "properties": {
+          "items": {
+            "description": "An array containing the execution items included in this response page.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v2_ExecutionResponse"
+            },
+            "type": "array"
+          },
+          "total_count": {
+            "description": "The total number of executions available in the system. This value is used for pagination purposes.",
+            "type": "integer"
+          }
+        },
+        "title": "ListExecutionsResponse",
+        "type": "object"
       },
-      "JsonErrorResponse": {
+      "1.5.0_v2_NotFound": {
+        "additionalProperties": false,
+        "description": "This response indicates that the requested resource could not be found in the system.",
+        "example": {
+          "errors": [
+            {
+              "detail": "The requested resource cannot be found.",
+              "title": "Not Found"
+            }
+          ]
+        },
         "properties": {
           "errors": {
+            "example": [
+              {
+                "detail": "The requested resource cannot be found.",
+                "title": "Not Found"
+              }
+            ],
+            "items": {
+              "properties": {
+                "detail": {
+                  "example": "The requested resource cannot be found.",
+                  "type": "string"
+                },
+                "title": {
+                  "example": "Not Found",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "title": "NotFound",
+        "type": "object"
+      },
+      "1.5.0_v2_StartExecutionRequest": {
+        "additionalProperties": false,
+        "description": "This schema defines the context and parameters required to start a check execution.",
+        "example": {
+          "env": {
+            "VAR1": "value1"
+          },
+          "execution_id": "e1a2b3c4-d5f6-7890-abcd-1234567890ab",
+          "group_id": "353fd789-d8ae-4a1b-a9f9-3919bd773e79",
+          "targets": [
+            {
+              "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+              "checks": [
+                "SLES-HA-1"
+              ]
+            }
+          ]
+        },
+        "properties": {
+          "env": {
+            "$ref": "#/components/schemas/1.5.0_v2_ExecutionEnv"
+          },
+          "execution_id": {
+            "description": "A unique identifier for the execution instance.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "group_id": {
+            "description": "A unique identifier for the group associated with this execution instance.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "target_type": {
+            "description": "Specifies the type of target for the execution process.",
+            "type": "string"
+          },
+          "targets": {
+            "description": "An array of agents that will participate in the execution process.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v2_Target"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "execution_id",
+          "group_id",
+          "targets"
+        ],
+        "title": "StartExecutionRequest",
+        "type": "object"
+      },
+      "1.5.0_v2_Target": {
+        "additionalProperties": false,
+        "description": "Represents the target where execution facts are gathered, including agent and check associations.",
+        "example": {
+          "agent_id": "a1b2c3d4-e5f6-7890-abcd-1234567890ab",
+          "checks": [
+            "SLES-HA-1"
+          ]
+        },
+        "properties": {
+          "agent_id": {
+            "description": "The unique identifier of the agent for which facts are gathered during execution.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "checks": {
+            "items": {
+              "description": "The unique identifier of the check associated with the target agent for execution.",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "agent_id",
+          "checks"
+        ],
+        "title": "Target",
+        "type": "object"
+      },
+      "1.5.0_v2_UnprocessableEntity": {
+        "additionalProperties": false,
+        "description": "This response indicates that the request could not be processed due to semantic errors or invalid data.",
+        "example": {
+          "errors": [
+            {
+              "detail": "null value where string expected",
+              "title": "Invalid value"
+            }
+          ]
+        },
+        "properties": {
+          "errors": {
+            "example": [
+              {
+                "detail": "null value where string expected",
+                "title": "Invalid value"
+              }
+            ],
             "items": {
               "properties": {
                 "detail": {
                   "example": "null value where string expected",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
-                },
-                "source": {
-                  "properties": {
-                    "pointer": {
-                      "example": "/data/attributes/petName",
-                      "type": "string",
-                      "x-struct": null,
-                      "x-validate": null
-                    }
-                  },
-                  "required": ["pointer"],
-                  "type": "object",
-                  "x-struct": null,
-                  "x-validate": null
+                  "type": "string"
                 },
                 "title": {
                   "example": "Invalid value",
-                  "type": "string",
-                  "x-struct": null,
-                  "x-validate": null
+                  "type": "string"
                 }
               },
-              "required": ["title", "source", "detail"],
-              "type": "object",
-              "x-struct": null,
-              "x-validate": null
+              "required": [
+                "title",
+                "detail"
+              ],
+              "type": "object"
             },
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
+            "type": "array"
           }
         },
-        "required": ["errors"],
-        "title": "JsonErrorResponse",
-        "type": "object",
-        "x-struct": "Elixir.OpenApiSpex.JsonErrorResponse",
-        "x-validate": null
+        "required": [
+          "errors"
+        ],
+        "title": "UnprocessableEntity",
+        "type": "object"
       },
-      "HttpSTDTargetList": {
-        "description": "Http discovery target list",
-        "items": {
-          "$ref": "#/components/schemas/HttpStd"
-        },
-        "title": "HttpSTDTargetList",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "HostsCollection": {
-        "description": "A list of the discovered hosts",
-        "items": {
-          "$ref": "#/components/schemas/Host"
-        },
-        "title": "HostsCollection",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SAPSystemHealthOverview": {
+      "1.5.0_v2_Value": {
         "additionalProperties": false,
-        "description": "An overview of the health of a discovered SAP System and its components",
+        "description": "Represents a value used in the expectations evaluation, including its name, check association, and customization status.",
+        "example": {
+          "check_id": "SLES-HA-1",
+          "customized": false,
+          "name": "fencing_configured",
+          "value": true
+        },
         "properties": {
-          "application_cluster_health": {
-            "$ref": "#/components/schemas/ResourceHealth"
+          "check_id": {
+            "description": "The unique identifier of the check associated with the value.",
+            "type": "string"
           },
-          "application_cluster_id": {
-            "description": "Application cluster ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "customized": {
+            "description": "Indicates whether the value has been customized for the expectations evaluation.",
+            "type": "boolean"
           },
-          "cluster_id": {
-            "deprecated": true,
-            "description": "Cluster ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "name": {
+            "description": "The name of the value used in the expectations evaluation.",
+            "type": "string"
           },
-          "clusters_health": {
-            "allOf": [
+          "value": {
+            "description": "The value used in the expectations evaluation, which may be a string, integer, boolean, or array.",
+            "oneOf": [
               {
-                "$ref": "#/components/schemas/ResourceHealth"
+                "type": "string"
               },
               {
-                "deprecated": true,
-                "x-struct": null,
-                "x-validate": null,
-                "nullable": true
+                "type": "number"
+              },
+              {
+                "type": "boolean"
               }
-            ],
-            "x-struct": null,
-            "x-validate": null
+            ]
+          }
+        },
+        "required": [
+          "check_id",
+          "name",
+          "value"
+        ],
+        "title": "Value",
+        "type": "object"
+      },
+      "1.5.0_v3_CatalogResponse": {
+        "additionalProperties": false,
+        "description": "This object represents the response for a catalog listing, including all available checks.",
+        "example": {
+          "items": [
+            {
+              "customization_disabled": true,
+              "description": "This check verifies whether fencing is configured for all cluster nodes to ensure high availability.",
+              "expectations": [
+                {
+                  "expression": "fencing_configured == true",
+                  "failure_message": "Fencing is not configured for all nodes.",
+                  "name": "fencing_enabled",
+                  "type": "expect_enum",
+                  "warning_message": "Warning: fencing may not be fully configured."
+                }
+              ],
+              "facts": [
+                {
+                  "argument": "",
+                  "gatherer": "cluster_node_gatherer",
+                  "name": "node_count"
+                }
+              ],
+              "group": "SLES-HA",
+              "id": "SLES-HA-1",
+              "metadata": {
+                "category": "ha",
+                "impact": "critical"
+              },
+              "name": "Cluster node fencing configured",
+              "premium": false,
+              "remediation": "Configure fencing for all cluster nodes to ensure high availability.",
+              "severity": "critical",
+              "values": [
+                {
+                  "conditions": [
+                    {
+                      "expression": "node_count > 1",
+                      "value": true
+                    }
+                  ],
+                  "customization_disabled": false,
+                  "default": false,
+                  "name": "fencing_configured"
+                }
+              ],
+              "when": "node_count > 0"
+            }
+          ]
+        },
+        "properties": {
+          "items": {
+            "description": "An array containing all catalog checks included in the response.",
+            "items": {
+              "$ref": "#/components/schemas/1.5.0_v3_Check"
+            },
+            "type": "array"
+          }
+        },
+        "title": "CatalogResponse",
+        "type": "object"
+      },
+      "1.5.0_v3_Check": {
+        "additionalProperties": false,
+        "description": "This object represents a single check from the catalog, including its configuration, metadata, and validation logic.",
+        "example": {
+          "customization_disabled": false,
+          "description": "Checks if fencing is configured for all cluster nodes.",
+          "expectations": [
+            {
+              "expression": "fencing_configured == true",
+              "failure_message": "Fencing is not configured for all nodes.",
+              "name": "fencing_enabled",
+              "type": "expect_enum",
+              "warning_message": "Warning: fencing may not be fully configured."
+            }
+          ],
+          "facts": [
+            {
+              "argument": "",
+              "gatherer": "cluster_node_gatherer",
+              "name": "node_count"
+            }
+          ],
+          "group": "SLES-HA",
+          "id": "SLES-HA-1",
+          "metadata": {
+            "category": "ha",
+            "impact": "critical"
           },
-          "database_cluster_health": {
-            "$ref": "#/components/schemas/ResourceHealth"
+          "name": "Cluster node fencing configured",
+          "premium": false,
+          "remediation": "Configure fencing for all cluster nodes to ensure high availability.",
+          "severity": "critical",
+          "values": [
+            {
+              "conditions": [
+                {
+                  "expression": "node_count > 1",
+                  "value": true
+                }
+              ],
+              "customization_disabled": false,
+              "default": false,
+              "name": "fencing_configured"
+            }
+          ],
+          "when": "node_count > 0"
+        },
+        "properties": {
+          "customization_disabled": {
+            "description": "Whether the check is customizable or not",
+            "type": "boolean"
           },
-          "database_cluster_id": {
-            "description": "Database cluster ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "description": {
+            "description": "A detailed explanation of the check, outlining its purpose and expected behavior.",
+            "type": "string"
           },
-          "database_health": {
-            "$ref": "#/components/schemas/ResourceHealth"
+          "expectations": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "expression": {
+                  "description": "The expression to be evaluated to get the expectation result for the check.",
+                  "type": "string"
+                },
+                "failure_message": {
+                  "description": "A message returned when the check fails, providing context for troubleshooting.",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "A label that identifies the expectation for the check.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Specifies the type of expectation for the check, such as expect or expect_same.",
+                  "enum": [
+                    "unknown",
+                    "expect",
+                    "expect_same",
+                    "expect_enum"
+                  ],
+                  "type": "string"
+                },
+                "warning_message": {
+                  "description": "Message returned when the check return value is warning. Only available for `expect_enum` expectations",
+                  "nullable": true,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type",
+                "expression",
+                "failure_message"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
-          "database_id": {
-            "description": "Database ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "facts": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "argument": {
+                  "description": "The argument provided to the gatherer for fact collection.",
+                  "type": "string"
+                },
+                "gatherer": {
+                  "description": "The gatherer used to collect the fact for the check.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The label for the fact gathered for the check.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "gatherer",
+                "argument"
+              ],
+              "type": "object"
+            },
+            "type": "array"
           },
-          "database_sid": {
-            "description": "Database SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "hosts_health": {
-            "$ref": "#/components/schemas/ResourceHealth"
+          "group": {
+            "description": "The logical group to which the check belongs, used for organization and filtering.",
+            "type": "string"
           },
           "id": {
-            "description": "SAP System ID",
-            "format": "uuid",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "A unique identifier for the check in the catalog.",
+            "type": "string"
           },
-          "sapsystem_health": {
-            "$ref": "#/components/schemas/ResourceHealth"
+          "metadata": {
+            "description": "Additional metadata associated with the check, providing context and categorization.",
+            "nullable": true,
+            "type": "object"
           },
-          "sid": {
-            "description": "SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+          "name": {
+            "description": "The name assigned to the check for identification and reporting purposes.",
+            "type": "string"
           },
-          "tenant": {
+          "premium": {
             "deprecated": true,
-            "description": "Tenant database SID",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
+            "description": "Check is Premium or not",
+            "type": "boolean"
+          },
+          "remediation": {
+            "description": "Guidance or steps to resolve issues detected by the check, helping users remediate problems.",
+            "type": "string"
+          },
+          "severity": {
+            "description": "Indicates the severity level of the check, such as critical or warning, to help prioritize remediation.",
+            "enum": [
+              "critical",
+              "warning"
+            ],
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "expression": {
+                        "description": "The expression to be evaluated to use the current value for the check.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The value to be used for this condition in the check.",
+                        "oneOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "expression"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "customization_disabled": {
+                  "description": "Indicates whether the value is customizable or not for this check.",
+                  "type": "boolean"
+                },
+                "default": {
+                  "description": "The default value used if none of the conditions matches for the check.",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
+                },
+                "name": {
+                  "description": "The label for the value used in the check.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "default",
+                "conditions",
+                "customization_disabled"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "when": {
+            "description": "Expression to determine whether a check should run",
+            "nullable": true,
+            "type": "string"
           }
         },
-        "title": "SAPSystemHealthOverview",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "required": [
+          "id",
+          "name",
+          "group",
+          "description",
+          "remediation",
+          "metadata",
+          "severity",
+          "facts",
+          "values",
+          "expectations",
+          "when",
+          "premium",
+          "customization_disabled"
+        ],
+        "title": "Check",
+        "type": "object"
       },
-      "Health": {
-        "additionalProperties": false,
+      "1.5.0_v3_ExecutionEnv": {
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/components/schemas/1.5.0_v3_ExecutionEnv"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "description": "Defines the contextual environment settings used during the current execution, allowing for flexible configuration.",
         "example": {
-          "database": "pass"
+          "DEBUG": true,
+          "MAX_RETRIES": 3,
+          "VAR1": "value1"
         },
-        "properties": {
-          "database": {
-            "description": "The status of the database connection",
-            "enum": ["pass", "fail"],
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "Health",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
+        "title": "ExecutionEnv",
+        "type": "object"
       },
-      "AvailableSoftwareUpdatesResponse": {
+      "1.5.0_v3_UnprocessableEntity": {
         "additionalProperties": false,
-        "description": "Response returned from the available software updates endpoint",
+        "description": "This response indicates that the request could not be processed due to semantic errors or invalid data.",
+        "example": {
+          "errors": [
+            {
+              "detail": "null value where string expected",
+              "title": "Invalid value"
+            }
+          ]
+        },
         "properties": {
-          "relevant_patches": {
-            "description": "A list relevant patches for the host",
+          "errors": {
+            "example": [
+              {
+                "detail": "null value where string expected",
+                "title": "Invalid value"
+              }
+            ],
             "items": {
-              "$ref": "#/components/schemas/RelevantPatch"
-            },
-            "title": "RelevantPatches",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "upgradable_packages": {
-            "description": "A list of upgradable packages for the host",
-            "items": {
-              "$ref": "#/components/schemas/UpgradablePackage"
-            },
-            "title": "UpgradablePackages",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "title": "AvailableSoftwareUpdatesResponse",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ApplicationInstances": {
-        "description": "A list of the discovered Application Instances for current SAP Systems",
-        "items": {
-          "$ref": "#/components/schemas/ApplicationInstance"
-        },
-        "title": "ApplicationInstances",
-        "type": "array",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "DeregisteredAt": {
-        "description": "Timestamp of the last deregistration of the host",
-        "format": "date-time",
-        "nullable": true,
-        "title": "DeregisteredAt",
-        "type": "string",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "SaptuneStatus": {
-        "additionalProperties": false,
-        "description": "Saptune status output on the host",
-        "nullable": true,
-        "properties": {
-          "applied_notes": {
-            "description": "A list of applied notes",
-            "items": {
-              "$ref": "#/components/schemas/SaptuneNote"
-            },
-            "title": "Applied notes",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "applied_solution": {
-            "$ref": "#/components/schemas/SaptuneSolution"
-          },
-          "configured_version": {
-            "description": "Saptune configure version",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "enabled_notes": {
-            "description": "A list of enabled notes",
-            "items": {
-              "$ref": "#/components/schemas/SaptuneNote"
-            },
-            "title": "Enabled notes",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "enabled_solution": {
-            "$ref": "#/components/schemas/SaptuneSolution"
-          },
-          "package_version": {
-            "description": "Saptune package version",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "services": {
-            "description": "A list of saptune services",
-            "items": {
-              "$ref": "#/components/schemas/SaptuneService"
-            },
-            "title": "Saptune services",
-            "type": "array",
-            "x-struct": null,
-            "x-validate": null
-          },
-          "staging": {
-            "$ref": "#/components/schemas/SaptuneStaging"
-          },
-          "tuning_state": {
-            "description": "Saptune tuning state",
-            "type": "string",
-            "x-struct": null,
-            "x-validate": null
-          }
-        },
-        "required": ["package_version"],
-        "title": "Saptune status",
-        "type": "object",
-        "x-struct": null,
-        "x-validate": null
-      },
-      "ProviderMetadata": {
-        "description": "Detected metadata for any provider",
-        "nullable": true,
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/AwsProviderData"
-          },
-          {
-            "$ref": "#/components/schemas/AzureProviderData"
-          },
-          {
-            "$ref": "#/components/schemas/GcpProviderData"
-          }
-        ],
-        "title": "ProviderMetadata",
-        "x-struct": null,
-        "x-validate": null
-      }
-    },
-    "securitySchemes": {}
-  },
-  "info": {
-    "description": "Easing your life in administering SAP applications",
-    "title": "Trento",
-    "version": "2.5.0"
-  },
-  "openapi": "3.0.0",
-  "paths": {
-    "/api/v1/checks/catalog": {
-      "get": {
-        "description": "Returns the checks catalog, with all the available checks.",
-        "operationId": "CatalogController_catalog",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CatalogResponse"
+              "properties": {
+                "detail": {
+                  "example": "null value where string expected",
+                  "type": "string"
+                },
+                "title": {
+                  "example": "Invalid value",
+                  "type": "string"
                 }
-              }
-            },
-            "description": "A list of all available checks in the catalog"
-          }
-        },
-        "summary": "Returns the checks catalog",
-        "tags": ["Catalog"]
-      }
-    },
-    "/api/v1/checks/executions": {
-      "get": {
-        "callbacks": {},
-        "operationId": "ExecutionController_index",
-        "parameters": [
-          {
-            "description": "Filter by group ID",
-            "example": "00000000-0000-0000-0000-000000000001",
-            "in": "query",
-            "name": "group_id",
-            "required": false,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Page",
-            "example": 3,
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Items per page",
-            "example": 20,
-            "in": "query",
-            "name": "items_per_page",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListExecutionsResponse"
-                }
-              }
-            },
-            "description": "List executions response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        },
-        "summary": "List executions",
-        "tags": []
-      }
-    },
-    "/api/v1/checks/executions/{id}": {
-      "get": {
-        "callbacks": {},
-        "operationId": "ExecutionController_show",
-        "parameters": [
-          {
-            "description": "Execution ID",
-            "example": "00000000-0000-0000-0000-000000000001",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExecutionResponse"
-                }
-              }
-            },
-            "description": "Execution"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        },
-        "summary": "Get an execution by ID",
-        "tags": []
-      }
-    },
-    "/api/v1/checks/groups/{id}/executions/last": {
-      "get": {
-        "callbacks": {},
-        "operationId": "ExecutionController_last",
-        "parameters": [
-          {
-            "description": "Group ID",
-            "example": "00000000-0000-0000-0000-000000000001",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExecutionResponse"
-                }
-              }
-            },
-            "description": "Execution"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        },
-        "summary": "Get the last execution of a group",
-        "tags": []
-      }
-    },
-    "/api/v1/groups/{group_id}/checks": {
-      "get": {
-        "callbacks": {},
-        "operationId": "CatalogController_selectable_checks",
-        "parameters": [
-          {
-            "description": "Identifier of the group for which selectable checks should be listed",
-            "example": "00000000-0000-0000-0000-000000000001",
-            "in": "path",
-            "name": "group_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "env variables",
-            "explode": true,
-            "in": "query",
-            "name": "env",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/ExecutionEnv"
-            },
-            "style": "form"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SelectableChecksResponse"
-                }
-              }
-            },
-            "description": "Selectable checks response"
-          }
-        },
-        "summary": "List selectable checks for a given execution group and environment",
-        "tags": []
-      }
-    },
-    "/api/v1/operations/executions": {
-      "get": {
-        "callbacks": {},
-        "operationId": "OperationController_index",
-        "parameters": [
-          {
-            "description": "Filter by group ID",
-            "example": "00000000-0000-0000-0000-000000000001",
-            "in": "query",
-            "name": "group_id",
-            "required": false,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Page",
-            "example": 3,
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Items per page",
-            "example": 20,
-            "in": "query",
-            "name": "items_per_page",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "enum": ["running", "completed", "aborted"],
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListOperationsResponse"
-                }
-              }
-            },
-            "description": "List operations response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        },
-        "summary": "List operations",
-        "tags": []
-      }
-    },
-    "/api/v1/operations/executions/{id}": {
-      "get": {
-        "callbacks": {},
-        "operationId": "OperationController_show",
-        "parameters": [
-          {
-            "description": "Operation ID",
-            "example": "00000000-0000-0000-0000-000000000001",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OperationResponse"
-                }
-              }
-            },
-            "description": "Operation"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        },
-        "summary": "Get an operation by ID",
-        "tags": []
-      }
-    },
-    "/api/v1/hosts": {
-      "get": {
-        "callbacks": {},
-        "description": "List all the discovered hosts on the target infrastructure",
-        "operationId": "HostController_list",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostsCollection"
-                }
-              }
-            },
-            "description": "A collection of the discovered hosts"
-          }
-        },
-        "summary": "List hosts",
-        "tags": ["Target Infrastructure"]
-      }
-    },
-    "/api/v1/databases": {
-      "get": {
-        "callbacks": {},
-        "description": "List all the discovered HANA Databases on the target infrastructure",
-        "operationId": "DatabaseController_list_databases",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DatabasesCollection"
-                }
-              }
-            },
-            "description": "A collection of the discovered HANA Databases"
-          }
-        },
-        "summary": "List HANA Databases",
-        "tags": ["Target Infrastructure"]
-      }
-    },
-    "/api/v1/sap_systems/health": {
-      "get": {
-        "callbacks": {},
-        "description": "Provide an aggregated overview of the health of the discovered SAP Systems (and their components) on the target infrastructure",
-        "operationId": "HealthOverviewController_overview",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HealthOverview"
-                }
-              }
-            },
-            "description": "An overview of the health of the discovered SAP Systems and their components"
-          }
-        },
-        "summary": "Health overview of the discovered SAP Systems",
-        "tags": ["Target Infrastructure"]
-      }
-    },
-    "/api/v2/clusters": {
-      "get": {
-        "callbacks": {},
-        "description": "List all the discovered Pacemaker Clusters on the target infrastructure",
-        "operationId": "ClusterController_list",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PacemakerClustersCollection"
-                }
-              }
-            },
-            "description": "A collection of the discovered Pacemaker Clusters"
-          }
-        },
-        "summary": "List Pacemaker Clusters",
-        "tags": ["Target Infrastructure"]
-      }
-    },
-    "/api/v1/sap_systems": {
-      "get": {
-        "callbacks": {},
-        "description": "List all the discovered SAP Systems on the target infrastructure",
-        "operationId": "SapSystemController_list",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SAPSystemsCollection"
-                }
-              }
-            },
-            "description": "A collection of the discovered SAP Systems"
-          }
-        },
-        "summary": "List SAP Systems",
-        "tags": ["Target Infrastructure"]
-      }
-    },
-    "/api/v1/software_updates/packages": {
-      "get": {
-        "callbacks": {},
-        "description": "Endpoint to fetch relevant patches covered by package upgrades in SUSE Manager",
-        "operationId": "SUSEManagerController_patches_for_packages",
-        "parameters": [
-          {
-            "description": "",
-            "in": "query",
-            "name": "host_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PatchesForPackagesResponse"
-                }
-              }
-            },
-            "description": "Available software updates for the host"
-          }
-        },
-        "summary": "Gets patches covered by package upgrades in SUSE Manager",
-        "tags": ["Platform"]
-      }
-    },
-    "/api/v1/hosts/{id}/software_updates": {
-      "get": {
-        "callbacks": {},
-        "description": "Endpoint to fetch available relevant patches and upgradable packages for a given host ID.",
-        "operationId": "SUSEManagerController_software_updates",
-        "parameters": [
-          {
-            "description": "",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AvailableSoftwareUpdatesResponse"
-                }
-              }
-            },
-            "description": "Available software updates for the host"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnprocessableEntity"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        },
-        "summary": "Gets available software updates for a given host",
-        "tags": ["Platform"]
-      }
-    },
-    "/api/v1/activity_log": {
-      "get": {
-        "callbacks": {},
-        "operationId": "ActivityLogController_get_activity_log",
-        "parameters": [
-          {
-            "description": "",
-            "in": "query",
-            "name": "first",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "last",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "after",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "before",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "from_date",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "to_date",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "actor",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
               },
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "search",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "type",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "x-struct": null,
-              "x-validate": null,
-              "items": {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
-              }
-            }
-          },
-          {
-            "description": "",
-            "in": "query",
-            "name": "severity",
-            "required": false,
-            "schema": {
-              "default": ["debug", "info", "warning", "critical"],
-              "type": "array",
-              "items": {
-                "type": "string",
-                "x-struct": null,
-                "x-validate": null
-              },
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActivityLog"
-                }
-              }
+              "required": [
+                "title",
+                "detail"
+              ],
+              "type": "object"
             },
-            "description": "Activity Log settings fetched successfully"
+            "type": "array"
           }
         },
-        "summary": "Fetches the Activity Log entries.",
-        "tags": ["Platform"]
+        "required": [
+          "errors"
+        ],
+        "title": "UnprocessableEntity",
+        "type": "object"
       }
     },
-    "/api/v1/hosts/{id}/heartbeat": {
-      "post": {
-        "callbacks": {},
-        "description": "This is used by the agents to signal that they are still alive.",
-        "operationId": "HostController_heartbeat",
-        "parameters": [
-          {
-            "description": "",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "The heartbeat has been updated"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/JsonErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        },
-        "summary": "Signal that an agent is alive",
-        "tags": ["Agent"]
-      }
-    },
-    "/api/v1/charts/hosts/{id}/cpu": {
-      "get": {
-        "callbacks": {},
-        "description": "Get information about cpu usage for a host, providing a from/to interval as ISO8601 timestamp",
-        "operationId": "ChartController_host_cpu",
-        "parameters": [
-          {
-            "description": "Host ID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "description": "Host ID",
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Start of the chart interval, as ISO8601 timestamp",
-            "in": "query",
-            "name": "from",
-            "required": true,
-            "schema": {
-              "description": "Start of the chart interval, as ISO8601 timestamp",
-              "format": "date-time",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "End of the chart interval, as ISO8601 timestamp",
-            "in": "query",
-            "name": "to",
-            "required": true,
-            "schema": {
-              "description": "End of the chart interval, as ISO8601 timestamp",
-              "format": "date-time",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostCpuChart"
-                }
-              }
-            },
-            "description": "Information about CPU usage of the host"
-          }
-        },
-        "summary": "Get a CPU chart of a host",
-        "tags": ["Charts"]
-      }
-    },
-    "/api/v1/charts/hosts/{id}/memory": {
-      "get": {
-        "callbacks": {},
-        "description": "Get information about memory usage for a host, providing a from/to interval as ISO8601 timestamp",
-        "operationId": "ChartController_host_memory",
-        "parameters": [
-          {
-            "description": "Host ID",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "description": "Host ID",
-              "format": "uuid",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "Start of the chart interval, as ISO8601 timestamp",
-            "in": "query",
-            "name": "from",
-            "required": true,
-            "schema": {
-              "description": "Start of the chart interval, as ISO8601 timestamp",
-              "format": "date-time",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          },
-          {
-            "description": "End of the chart interval, as ISO8601 timestamp",
-            "in": "query",
-            "name": "to",
-            "required": true,
-            "schema": {
-              "description": "End of the chart interval, as ISO8601 timestamp",
-              "format": "date-time",
-              "type": "string",
-              "x-struct": null,
-              "x-validate": null
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HostMemoryChart"
-                }
-              }
-            },
-            "description": "Information about memory usage of the host"
-          }
-        },
-        "summary": "Get a Memory chart of a host",
-        "tags": ["Charts"]
+    "securitySchemes": {
+      "authorization": {
+        "description": "Bearer token authentication",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
-  },
-  "servers": [
-    {
-      "url": "https://example.com",
-      "variables": {}
-    }
-  ],
-  "tags": [
-    {
-      "description": "Providing access to the discovered target infrastructure",
-      "name": "Target Infrastructure"
-    },
-    {
-      "description": "Providing Checks related feature",
-      "name": "Checks"
-    },
-    {
-      "description": "Providing access to Trento Platform features",
-      "name": "Platform"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
# Description

This PR just updates the API docs to a temporary version, which is the result of merging some open PRs (https://github.com/trento-project/web/pull/3686, https://github.com/trento-project/web/pull/3742, https://github.com/trento-project/web/pull/3743, https://github.com/trento-project/web/pull/3744, https://github.com/trento-project/web/pull/3746, https://github.com/trento-project/wanda/pull/634 and https://github.com/trento-project/wanda/pull/635) and consolidating the Web and Wanda APIs in a single file. 

This is the same we did (manually) in the current file. To be clear, this is just an update of the existing workaround. We still need a proper mechanism to ensure the MCP server gets the API docs from Trento directly.

Related #TRNT-3845

## How was this tested?

IRL tests.