### PR TITLE
[TRNT-3854] Replace ubuntu-latest with ubuntu-24.04

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -8,7 +8,7 @@ jobs:
   # Run Go static analysis tools (vet, fmt, golangci-lint) to ensure code quality and style.
   static-code-analysis:
     name: Check Go static analysis tools
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the repository.
       - uses: actions/checkout@v5
@@ -45,7 +45,7 @@ jobs:
   # Check that all source files have the correct license headers.
   linter-license-headers:
     name: Check license headers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the repository.
       - uses: actions/checkout@v5
@@ -57,7 +57,7 @@ jobs:
   # Lint all AsciiDoc documentation files using asciidoctor and a custom script.
   linter-documentation:
     name: Check documentation files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the repository.
       - uses: actions/checkout@v5
@@ -74,7 +74,7 @@ jobs:
   # Run ShellCheck on all shell scripts to catch common scripting errors.
   linter-shellscripts:
     name: Check shell scripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the repository.
       - uses: actions/checkout@v5

--- a/.github/workflows/obs.yaml
+++ b/.github/workflows/obs.yaml
@@ -30,7 +30,7 @@ jobs:
   # This job prepares sources, updates dependencies, optionally updates the changelog, and commits changes to OBS.
   update-image:
     name: Update 'mcp-server-trento-image' package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       # See https://github.com/trento-project/continuous-delivery
       image: ghcr.io/trento-project/continuous-delivery:main
@@ -132,7 +132,7 @@ jobs:
   # This job prepares sources, updates dependencies, optionally updates the changelog, and commits changes to OBS.
   update-rpm:
     name: Update 'mcp-server-trento' package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       # See https://github.com/trento-project/continuous-delivery
       image: ghcr.io/trento-project/continuous-delivery:main

--- a/.github/workflows/pipeline-definition.yaml
+++ b/.github/workflows/pipeline-definition.yaml
@@ -23,7 +23,7 @@ jobs:
   # Set up environment variables and outputs for downstream jobs.
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       # Output variables for use in other jobs.
       img_modifier: ${{ steps.set-outputs.outputs.img_modifier }}
@@ -112,7 +112,7 @@ jobs:
     name: Check linters result
     if: inputs.run_linters && always()
     needs: linters-run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Fail the job if any linter did not succeed.
       - name: Check all linters result
@@ -124,7 +124,7 @@ jobs:
     name: Check Go test suite
     needs:
       - setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the repository.
       - uses: actions/checkout@v5
@@ -153,7 +153,7 @@ jobs:
     name: Check Helm chart
     needs:
       - setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the repository.
       - uses: actions/checkout@v5
@@ -189,7 +189,7 @@ jobs:
     name: "Build ${{matrix.image}} image"
     needs:
       - setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -245,7 +245,7 @@ jobs:
   generate-docs:
     name: Update Go docs site
     if: needs.setup.outputs.running_on_main == 'true' || inputs.trigger_release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - setup
       - build-container-images
@@ -262,7 +262,7 @@ jobs:
   push_images:
     name: Push container images
     if: needs.setup.outputs.running_on_main == 'true' || inputs.trigger_release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write # required for creating ghcr.io packages.
@@ -338,7 +338,7 @@ jobs:
     name: Cleanup
     needs:
       - push_images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Delete image artifacts after pushing to the registry.
       - uses: geekyeggo/delete-artifact@v5


### PR DESCRIPTION
# Description

As per this comment:

> are you sure on using `latest`?
> We at least had many problems with this, and always opted to have a pinned version

_Originally posted by @arbulu89 in https://github.com/trento-project/mcp-server/pull/45#discussion_r2367639704_
            
This PR changes replaces all the `latest` versions with a fixed one.

## How was this tested?

CI