### PR TITLE
[TRNT-4228] Fix linter issues

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.25.0
-golangci-lint 2.5.0
+golangci-lint 2.10.1
 make 4.4.1
 shellcheck 0.11.0
-yamllint 1.37.1
+yamllint 1.38.0

--- a/internal/server/heathcheck_server.go
+++ b/internal/server/heathcheck_server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// Copyright 2025-2026 SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package server

--- a/internal/server/heathcheck_server.go
+++ b/internal/server/heathcheck_server.go
@@ -32,11 +32,6 @@ const (
 	wandaCheckName = "wanda"
 	// wandaCheckName is the name for the web check.
 	webCheckName = "web"
-
-	// httpScheme is the HTTP scheme used for health checks.
-	httpScheme = "http"
-	// httpsScheme is the HTTPS scheme used for health checks.
-	httpsScheme = "https"
 )
 
 // createLivenessChecker creates and returns a liveness health check handler.
@@ -229,7 +224,7 @@ func checkMCPServer(ctx context.Context, serveOpts *ServeOptions) error {
 	case utils.TransportSSE:
 		mcpTransport = &mcp.SSEClientTransport{
 			Endpoint: (&url.URL{
-				Scheme: httpScheme,
+				Scheme: utils.HttpScheme,
 				Host:   fmt.Sprintf("localhost:%d", serveOpts.Port),
 				Path:   "/sse",
 			}).String(),
@@ -240,7 +235,7 @@ func checkMCPServer(ctx context.Context, serveOpts *ServeOptions) error {
 	case utils.TransportStreamable:
 		mcpTransport = &mcp.StreamableClientTransport{
 			Endpoint: (&url.URL{
-				Scheme: httpScheme,
+				Scheme: utils.HttpScheme,
 				Host:   fmt.Sprintf("localhost:%d", serveOpts.Port),
 				Path:   "/mcp",
 			}).String(),
@@ -290,12 +285,9 @@ func checkAPIServiceHealth(
 		return fmt.Errorf("invalid health URL %s: %w", healthURL, err)
 	}
 
-	if parsedURL.Scheme != httpScheme && parsedURL.Scheme != httpsScheme {
-		return fmt.Errorf("unsupported protocol scheme %q", parsedURL.Scheme)
-	}
-
-	if parsedURL.Host == "" {
-		return fmt.Errorf("health URL must contain a host: %s", healthURL)
+	err = utils.ValidateHTTPURL(parsedURL)
+	if err != nil {
+		return err
 	}
 
 	// Create the HTTP request using the validated parsedURL

--- a/internal/server/heathcheck_server.go
+++ b/internal/server/heathcheck_server.go
@@ -32,6 +32,11 @@ const (
 	wandaCheckName = "wanda"
 	// wandaCheckName is the name for the web check.
 	webCheckName = "web"
+
+	// httpScheme is the HTTP scheme used for health checks.
+	httpScheme = "http"
+	// httpsScheme is the HTTPS scheme used for health checks.
+	httpsScheme = "https"
 )
 
 // createLivenessChecker creates and returns a liveness health check handler.
@@ -66,24 +71,25 @@ func createReadinessChecker(ctx context.Context, serveOpts *ServeOptions) http.H
 		Timeout: 5 * time.Second,
 	}
 
-	// Start with the MCP server check
-	checks := []health.Check{
-		{
-			Name: "mcp-server",
-			Check: func(ctx context.Context) error {
-				// Check connectivity to the MCP server using an MCP client.
-				return checkMCPServer(ctx, serveOpts)
-			},
+	// Precompute OAS checks so we can preallocate capacity
+	oasChecks := createOASPathHealthChecks(ctx, serveOpts, httpClient)
+
+	// Start with the MCP server check and preallocate capacity for all checks
+	checks := make([]health.Check, 0, 1+len(oasChecks))
+	checks = append(checks, health.Check{
+		Name: "mcp-server",
+		Check: func(ctx context.Context) error {
+			return checkMCPServer(ctx, serveOpts)
 		},
-	}
+	})
 
 	slog.InfoContext(ctx, "creating health check for MCP server")
 
 	// Add individual health checks for each OAS path
-	checks = append(checks, createOASPathHealthChecks(ctx, serveOpts, httpClient)...)
+	checks = append(checks, oasChecks...)
 
-	// Build the checker options
-	options := []health.CheckerOption{}
+	// Build the checker options and preallocate based on number of checks
+	options := make([]health.CheckerOption, 0, len(checks))
 	for _, check := range checks {
 		options = append(options, health.WithCheck(check))
 	}
@@ -223,7 +229,7 @@ func checkMCPServer(ctx context.Context, serveOpts *ServeOptions) error {
 	case utils.TransportSSE:
 		mcpTransport = &mcp.SSEClientTransport{
 			Endpoint: (&url.URL{
-				Scheme: "http",
+				Scheme: httpScheme,
 				Host:   fmt.Sprintf("localhost:%d", serveOpts.Port),
 				Path:   "/sse",
 			}).String(),
@@ -234,7 +240,7 @@ func checkMCPServer(ctx context.Context, serveOpts *ServeOptions) error {
 	case utils.TransportStreamable:
 		mcpTransport = &mcp.StreamableClientTransport{
 			Endpoint: (&url.URL{
-				Scheme: "http",
+				Scheme: httpScheme,
 				Host:   fmt.Sprintf("localhost:%d", serveOpts.Port),
 				Path:   "/mcp",
 			}).String(),

--- a/internal/server/heathcheck_server.go
+++ b/internal/server/heathcheck_server.go
@@ -284,8 +284,22 @@ func checkAPIServiceHealth(
 	serveOpts *ServeOptions,
 	httpClient *http.Client,
 ) error {
-	// Create the HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+	// Validate the health URL
+	parsedURL, err := url.Parse(healthURL)
+	if err != nil {
+		return fmt.Errorf("invalid health URL %s: %w", healthURL, err)
+	}
+
+	if parsedURL.Scheme != httpScheme && parsedURL.Scheme != httpsScheme {
+		return fmt.Errorf("unsupported protocol scheme %q", parsedURL.Scheme)
+	}
+
+	if parsedURL.Host == "" {
+		return fmt.Errorf("health URL must contain a host: %s", healthURL)
+	}
+
+	// Create the HTTP request using the validated parsedURL
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request for %s: %w", healthURL, err)
 	}
@@ -293,8 +307,14 @@ func checkAPIServiceHealth(
 	// Set User-Agent header
 	req.Header.Set("User-Agent", fmt.Sprintf("%s/%s", serveOpts.Name, serveOpts.Version))
 
-	// Make the request
-	resp, err := httpClient.Do(req)
+	// Make the request through the configured RoundTripper.
+	// This avoids automatic redirect handling and keeps the request path explicit.
+	transport := httpClient.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		return fmt.Errorf("failed to connect to %s (derived from OAS path %s): %w", healthURL, oasPath, err)
 	}

--- a/internal/server/heathcheck_server.go
+++ b/internal/server/heathcheck_server.go
@@ -224,7 +224,7 @@ func checkMCPServer(ctx context.Context, serveOpts *ServeOptions) error {
 	case utils.TransportSSE:
 		mcpTransport = &mcp.SSEClientTransport{
 			Endpoint: (&url.URL{
-				Scheme: utils.HttpScheme,
+				Scheme: utils.HTTPScheme,
 				Host:   fmt.Sprintf("localhost:%d", serveOpts.Port),
 				Path:   "/sse",
 			}).String(),
@@ -235,7 +235,7 @@ func checkMCPServer(ctx context.Context, serveOpts *ServeOptions) error {
 	case utils.TransportStreamable:
 		mcpTransport = &mcp.StreamableClientTransport{
 			Endpoint: (&url.URL{
-				Scheme: utils.HttpScheme,
+				Scheme: utils.HTTPScheme,
 				Host:   fmt.Sprintf("localhost:%d", serveOpts.Port),
 				Path:   "/mcp",
 			}).String(),

--- a/internal/server/mcp_server.go
+++ b/internal/server/mcp_server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// Copyright 2025-2026 SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package server

--- a/internal/server/mcp_server.go
+++ b/internal/server/mcp_server.go
@@ -263,17 +263,13 @@ func registerToolsFromSpec(srv *mcp.Server, oasDoc *openapi3.T, serveOpts *Serve
 		ConfirmDangerousActions: false, // TODO(agamez): not really working IRL, make it configurable?
 		RequestHandler: func(req *http.Request) (*http.Response, error) {
 			// Validate the request URL to mitigate SSRF (gosec G704).
-			if req == nil || req.URL == nil {
-				return nil, fmt.Errorf("invalid request: missing URL")
+			if req == nil {
+				return nil, fmt.Errorf("invalid request: missing request")
 			}
 
-			parsed := req.URL
-			if parsed.Scheme != "http" && parsed.Scheme != "https" {
-				return nil, fmt.Errorf("unsupported protocol scheme %q", parsed.Scheme)
-			}
-
-			if parsed.Host == "" {
-				return nil, fmt.Errorf("request URL must contain a host: %s", parsed.String())
+			err := utils.ValidateHTTPURL(req.URL)
+			if err != nil {
+				return nil, err
 			}
 
 			// Use the client's transport RoundTrip to avoid opaque Do sinks and automatic redirects.
@@ -343,12 +339,9 @@ func loadOpenAPISpecFromURL(ctx context.Context, path string, serveOpts *ServeOp
 		return nil, fmt.Errorf("invalid OpenAPI spec URL %s: %w", path, err)
 	}
 
-	if parsedPath.Scheme != "http" && parsedPath.Scheme != "https" {
-		return nil, fmt.Errorf("unsupported protocol scheme %q", parsedPath.Scheme)
-	}
-
-	if parsedPath.Host == "" {
-		return nil, fmt.Errorf("OpenAPI spec URL must contain a host: %s", path)
+	err = utils.ValidateHTTPURL(parsedPath)
+	if err != nil {
+		return nil, err
 	}
 
 	// Generate the GET request using the validated URL.

--- a/internal/server/mcp_server.go
+++ b/internal/server/mcp_server.go
@@ -262,7 +262,27 @@ func registerToolsFromSpec(srv *mcp.Server, oasDoc *openapi3.T, serveOpts *Serve
 		TagFilter:               nil,   // TODO(agamez): revert back to "serveOpts.TagFilter," once we can.
 		ConfirmDangerousActions: false, // TODO(agamez): not really working IRL, make it configurable?
 		RequestHandler: func(req *http.Request) (*http.Response, error) {
-			return httpClient.Do(req)
+			// Validate the request URL to mitigate SSRF (gosec G704).
+			if req == nil || req.URL == nil {
+				return nil, fmt.Errorf("invalid request: missing URL")
+			}
+
+			parsed := req.URL
+			if parsed.Scheme != "http" && parsed.Scheme != "https" {
+				return nil, fmt.Errorf("unsupported protocol scheme %q", parsed.Scheme)
+			}
+
+			if parsed.Host == "" {
+				return nil, fmt.Errorf("request URL must contain a host: %s", parsed.String())
+			}
+
+			// Use the client's transport RoundTrip to avoid opaque Do sinks and automatic redirects.
+			transport := httpClient.Transport
+			if transport == nil {
+				transport = http.DefaultTransport
+			}
+
+			return transport.RoundTrip(req)
 		},
 		NameFormat: func(oldOperationID string) string {
 			// Convert dots to underscores first
@@ -317,8 +337,22 @@ func loadOpenAPISpecFromURL(ctx context.Context, path string, serveOpts *ServeOp
 		Timeout: 30 * time.Second,
 	}
 
-	// Generate the GET request.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+	// Validate and parse the path URL
+	parsedPath, err := url.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid OpenAPI spec URL %s: %w", path, err)
+	}
+
+	if parsedPath.Scheme != "http" && parsedPath.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported protocol scheme %q", parsedPath.Scheme)
+	}
+
+	if parsedPath.Host == "" {
+		return nil, fmt.Errorf("OpenAPI spec URL must contain a host: %s", path)
+	}
+
+	// Generate the GET request using the validated URL.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedPath.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -326,8 +360,13 @@ func loadOpenAPISpecFromURL(ctx context.Context, path string, serveOpts *ServeOp
 	// Set the UA to track the version.
 	req.Header.Set("User-Agent", fmt.Sprintf("%s/%s", serveOpts.Name, serveOpts.Version))
 
-	// Perform the request.
-	resp, err := client.Do(req)
+	// Perform the request via the client's transport to avoid opaque Do sinks and automatic redirects.
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	resp, err := transport.RoundTrip(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch OpenAPI spec from URL: %w", err)
 	}

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -57,7 +57,7 @@ func TestStartSSEServer(t *testing.T) {
 			srv := server.CreateMCPServer(ctx, &server.ServeOptions{Name: "test", Version: "v1"})
 			port := getAvailablePort(t)
 			listenAddr := fmt.Sprintf(":%d", port)
-			checkURL := (&url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
+			checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
 
 			testServerShutdown(t, cancel, func() error {
 				serverErrChan := make(chan error, 1)
@@ -105,7 +105,7 @@ func TestStartStreamableHTTPServer(t *testing.T) {
 			srv := server.CreateMCPServer(ctx, &server.ServeOptions{Name: "test", Version: "v1"})
 			port := getAvailablePort(t)
 			listenAddr := fmt.Sprintf(":%d", port)
-			checkURL := (&url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
+			checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
 
 			testServerShutdown(t, cancel, func() error {
 				serverErrChan := make(chan error, 1)
@@ -165,7 +165,7 @@ func TestStartServer(t *testing.T) {
 
 			port := getAvailablePort(t)
 			listenAddr := fmt.Sprintf(":%d", port)
-			checkURL := (&url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", port)}).String()
+			checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port)}).String()
 
 			testServerShutdown(t, cancel, func() error {
 				serverErrChan := make(chan error, 1)
@@ -677,7 +677,7 @@ func TestHandleMCPServerRun(t *testing.T) {
 					assert.Contains(t, err.Error(), tt.errContains)
 				}
 			} else {
-				checkURL := (&url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", port), Path: tt.path}).String()
+				checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.path}).String()
 				testServerShutdown(t, cancel, func() error {
 					serverErrChan := make(chan error, 1)
 

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -57,7 +57,7 @@ func TestStartSSEServer(t *testing.T) {
 			srv := server.CreateMCPServer(ctx, &server.ServeOptions{Name: "test", Version: "v1"})
 			port := getAvailablePort(t)
 			listenAddr := fmt.Sprintf(":%d", port)
-			checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
+			checkURL := (&url.URL{Scheme: utils.HTTPScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
 
 			testServerShutdown(t, cancel, func() error {
 				serverErrChan := make(chan error, 1)
@@ -105,7 +105,7 @@ func TestStartStreamableHTTPServer(t *testing.T) {
 			srv := server.CreateMCPServer(ctx, &server.ServeOptions{Name: "test", Version: "v1"})
 			port := getAvailablePort(t)
 			listenAddr := fmt.Sprintf(":%d", port)
-			checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
+			checkURL := (&url.URL{Scheme: utils.HTTPScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.checkPath}).String()
 
 			testServerShutdown(t, cancel, func() error {
 				serverErrChan := make(chan error, 1)
@@ -165,7 +165,7 @@ func TestStartServer(t *testing.T) {
 
 			port := getAvailablePort(t)
 			listenAddr := fmt.Sprintf(":%d", port)
-			checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port)}).String()
+			checkURL := (&url.URL{Scheme: utils.HTTPScheme, Host: fmt.Sprintf("localhost:%d", port)}).String()
 
 			testServerShutdown(t, cancel, func() error {
 				serverErrChan := make(chan error, 1)
@@ -677,7 +677,7 @@ func TestHandleMCPServerRun(t *testing.T) {
 					assert.Contains(t, err.Error(), tt.errContains)
 				}
 			} else {
-				checkURL := (&url.URL{Scheme: utils.HttpScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.path}).String()
+				checkURL := (&url.URL{Scheme: utils.HTTPScheme, Host: fmt.Sprintf("localhost:%d", port), Path: tt.path}).String()
 				testServerShutdown(t, cancel, func() error {
 					serverErrChan := make(chan error, 1)
 

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// Copyright 2025-2026 SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:lll

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -723,7 +723,7 @@ func waitForServerReady(t *testing.T, urlStr string, timeout time.Duration) {
 	for time.Now().Before(deadline) {
 		// Use client.Do to ensure the context is passed for cancellation
 		// and to avoid issues with client.Get's default redirect behavior
-		resp, err := client.Do(req)
+		resp, err := client.Do(req) // nolint:gosec // This is just a test, no SSRF risk
 		if err == nil {
 			_ = resp.Body.Close()
 			// Consider the server ready if it returns any non-5xx response.
@@ -788,7 +788,7 @@ func createTempOASFile(t *testing.T, oasContent string) string {
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "openapi-*.json")
 	require.NoError(t, err)
-	t.Cleanup(func() { err = os.Remove(tmpFile.Name()); require.NoError(t, err) })
+	t.Cleanup(func() { err = os.Remove(tmpFile.Name()); require.NoError(t, err) }) // nolint:gosec // This is just a test, no SSRF risk
 
 	_, err = tmpFile.WriteString(oasContent)
 	require.NoError(t, err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// Copyright 2025-2026 SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package server_test is the where the server logic is tested.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -93,7 +93,7 @@ func TestServe(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.errContains)
 			} else {
 				checkURL := (&url.URL{
-					Scheme: "http",
+					Scheme: utils.HttpScheme,
 					Host:   fmt.Sprintf("localhost:%d", port),
 					Path:   tt.path,
 				}).String()
@@ -233,7 +233,7 @@ func TestWaitForShutdown(t *testing.T) {
 				}()
 
 				checkURL := (&url.URL{
-					Scheme: "http",
+					Scheme: utils.HttpScheme,
 					Host:   fmt.Sprintf("localhost:%d", port),
 					Path:   tt.checkPath,
 				}).String()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -93,7 +93,7 @@ func TestServe(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.errContains)
 			} else {
 				checkURL := (&url.URL{
-					Scheme: utils.HttpScheme,
+					Scheme: utils.HTTPScheme,
 					Host:   fmt.Sprintf("localhost:%d", port),
 					Path:   tt.path,
 				}).String()
@@ -233,7 +233,7 @@ func TestWaitForShutdown(t *testing.T) {
 				}()
 
 				checkURL := (&url.URL{
-					Scheme: utils.HttpScheme,
+					Scheme: utils.HTTPScheme,
 					Host:   fmt.Sprintf("localhost:%d", port),
 					Path:   tt.checkPath,
 				}).String()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -252,7 +252,7 @@ func TestWaitForShutdown(t *testing.T) {
 				require.NoError(t, err)
 
 				client := &http.Client{}
-				resp, err := client.Do(req)
+				resp, err := client.Do(req) // nolint:gosec // This is just a test, no SSRF risk
 				require.Error(t, err, "Server should be down")
 
 				if resp != nil && resp.Body != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,31 @@
+// Copyright 2026 SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	HttpScheme  = "http"
+	HttpsScheme = "https"
+)
+
+// ValidateHTTPURL validates scheme and host constraints for outbound HTTP requests.
+func ValidateHTTPURL(parsedURL *url.URL) error {
+	if parsedURL == nil {
+		return fmt.Errorf("invalid URL: missing URL")
+	}
+
+	if parsedURL.Scheme != HttpScheme && parsedURL.Scheme != HttpsScheme {
+		return fmt.Errorf("invalid URL: unsupported protocol scheme %q", parsedURL.Scheme)
+	}
+
+	if parsedURL.Host == "" {
+		return fmt.Errorf("invalid URL: missing host in %s", parsedURL.String())
+	}
+
+	return nil
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,7 +1,7 @@
 // Copyright 2026 SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-package utils
+package utils //nolint:revive
 
 import (
 	"fmt"
@@ -9,8 +9,10 @@ import (
 )
 
 const (
-	HttpScheme  = "http"
-	HttpsScheme = "https"
+	// HTTPScheme is the HTTPS scheme
+	HTTPScheme = "http"
+	// HTTPSScheme is the HTTP scheme
+	HTTPSScheme = "https"
 )
 
 // ValidateHTTPURL validates scheme and host constraints for outbound HTTP requests.
@@ -19,7 +21,7 @@ func ValidateHTTPURL(parsedURL *url.URL) error {
 		return fmt.Errorf("invalid URL: missing URL")
 	}
 
-	if parsedURL.Scheme != HttpScheme && parsedURL.Scheme != HttpsScheme {
+	if parsedURL.Scheme != HTTPScheme && parsedURL.Scheme != HTTPSScheme {
 		return fmt.Errorf("invalid URL: unsupported protocol scheme %q", parsedURL.Scheme)
 	}
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trento-project/mcp-server/internal/utils"
+)
+
+func TestValidateHTTPURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		url         string
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:      "valid HTTP URL",
+			url:       "http://example.com",
+			expectErr: false,
+		},
+		{
+			name:      "valid HTTPS URL",
+			url:       "https://example.com",
+			expectErr: false,
+		},
+		{
+			name:        "invalid URL",
+			url:         "ftp://example.com",
+			expectErr:   true,
+			errContains: "unsupported protocol scheme",
+		},
+		{
+			name:        "missing host",
+			url:         "http://",
+			expectErr:   true,
+			errContains: "missing host",
+		},
+		{
+			name:        "nil URL",
+			url:         "",
+			expectErr:   true,
+			errContains: "missing URL",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var parsedURL *url.URL
+			var err error
+
+			if tc.url != "" {
+				parsedURL, err = url.Parse(tc.url)
+				require.NoError(t, err)
+			}
+
+			err = utils.ValidateHTTPURL(parsedURL)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR bumps some dev deps up and fixes some linter errors that were preventing some dependabot updates from being merged.

Worth mentioning that recent `gosec` linter version now includes SSA representation, which improves the static analysis of the code (and detects SSRF,  QSL injections, etc.). 

This PR also includes some fixes to prevent those SSRF attacks by using `RoundTripper` instead of `Do` and validating the URL beforehand. This is to fix the linter issues.

Related TRNT-4228

## How was this tested?

Unit tests, linters
