### PR TITLE
[TRNT-4358] Update license headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Continuous Integration
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,4 +1,6 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Lib - Linters section
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 name: Release
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # Binaries for programs and plugins

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,23 +1,28 @@
-# Copyright 2025-2026 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
----
 header:
   comment: on-failure
   license:
+    spdx-id: Apache-2.0
     copyright-owner: SUSE LLC
     software-name: mcp-server-trento
     content: |
-      Copyright 2025-2026 SUSE LLC
+      SPDX-FileCopyrightText: SUSE LLC
       SPDX-License-Identifier: Apache-2.0
-    pattern: |
-      Copyright (?:\d{4}-\d{4}|\d{4}) SUSE LLC
   paths-ignore:
-    - .github/
-    - .tool-versions
+    - "**/*.adoc"
+    - "**/*.example"
+    - "**/*.json"
+    - "**/*.md"
+    - "**/*.pem"
+    - "**/*.service"
+    - "**/*.svg"
+    - "**/*.txt"
+    - ".github/CODEOWNERS"
+    - ".github/dependabot.yml"
+    - ".tool-versions"
+    - "LICENSE"
+    - "VERSION"
     - CHANGELOG.md
-    - LICENSE
-    - VERSION
     - go.sum
-    - packaging/suse/container/README.md
-    - packaging/suse/rpm/systemd/mcp-server-trento.service

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -22,7 +22,7 @@ header:
     - ".github/CODEOWNERS"
     - ".github/dependabot.yml"
     - ".tool-versions"
+    - "CHANGELOG.md"
     - "LICENSE"
     - "VERSION"
-    - CHANGELOG.md
-    - go.sum
+    - "go.sum"

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,5 +1,6 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
+
 ---
 extends: default
 rules:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 ARG GO_VERSION=1.25

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # Makefile variables

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
 ifndef::site-gen-antora[:relfileprefix: docs/]
 :badge-url: https://vscode.dev/redirect/mcp/install?name=trento&config=%7B%22servers%22%3A%7B%22mcp-server-trento%22%3A%7B%22type%22%3A%22http%22%2C%22url%22%3A%22http%3A//localhost%3A5000/mcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22your-trento-pat%22%7D%7D%7D%7D
 :badge-img: https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:gochecknoglobals

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package cmd holds the definition of CLI commands.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd_test

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/trento-project/mcp-server/internal/utils"
 )
 
-//nolint:paralleltest
+//nolint:paralleltest,goconst
 func TestExecute(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -127,7 +127,7 @@ func TestExecute(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest
+//nolint:paralleltest,goconst
 func TestInitLogger(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -170,6 +170,7 @@ func TestInitLogger(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestConfigureCLI(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -317,7 +318,7 @@ func TestConfigureCLI(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest
+//nolint:paralleltest,goconst
 func TestReadConfigFile(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package cmd

--- a/docs/Developer/README.adoc
+++ b/docs/Developer/README.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 = Trento MCP Server developer documentation
 
 == Documentation overview

--- a/docs/Developer/getting-started.adoc
+++ b/docs/Developer/getting-started.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 = Getting Started with Trento MCP Server
 
 This guide provides everything you need to start developing with the `Trento MCP Server`. It covers environment setup, project architecture, building, running, testing, and debugging.

--- a/docs/Trento MCP Server documentation/README.adoc
+++ b/docs/Trento MCP Server documentation/README.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 ifndef::imagesdir[:imagesdir: ../images]
 
 = Trento MCP Server documentation

--- a/docs/Trento MCP Server documentation/configuration-options.adoc
+++ b/docs/Trento MCP Server documentation/configuration-options.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 ifndef::imagesdir[:imagesdir: ../images]
 
 = Configuration Options

--- a/docs/Trento MCP Server documentation/installation.adoc
+++ b/docs/Trento MCP Server documentation/installation.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 ifndef::imagesdir[:imagesdir: ../images]
 
 = Installing the Trento MCP Server

--- a/docs/Trento MCP Server documentation/integration-others.adoc
+++ b/docs/Trento MCP Server documentation/integration-others.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 ifndef::imagesdir[:imagesdir: ../images]
 
 :badge-url: https://vscode.dev/redirect/mcp/install?name=trento&config=%7B%22servers%22%3A%7B%22mcp-server-trento%22%3A%7B%22type%22%3A%22http%22%2C%22url%22%3A%22http%3A//localhost%3A5000/mcp%22%2C%22headers%22%3A%7B%22Authorization%22%3A%22your-trento-pat%22%7D%7D%7D%7D

--- a/docs/Trento MCP Server documentation/integration-sles.adoc
+++ b/docs/Trento MCP Server documentation/integration-sles.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 ifndef::imagesdir[:imagesdir: ../images]
 
 = Integrating the Trento MCP Server with SLES 16

--- a/docs/Trento MCP Server documentation/integration-suse-ai.adoc
+++ b/docs/Trento MCP Server documentation/integration-suse-ai.adoc
@@ -1,6 +1,3 @@
-// Copyright 2025 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 ifndef::imagesdir[:imagesdir: ../images]
 
 = Integrating the Trento MCP Server with SUSE AI

--- a/docs/examples/Dockerfile
+++ b/docs/examples/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 FROM ollama/ollama:latest

--- a/docs/examples/values.openwebui.yaml
+++ b/docs/examples/values.openwebui.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 module github.com/trento-project/mcp-server

--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 set -e

--- a/hack/linters/asciidoc-linter.sh
+++ b/hack/linters/asciidoc-linter.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Copyright 2025 SUSE LLC
+
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/hack/linters/license-linter.sh
+++ b/hack/linters/license-linter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/hack/linters/replace-with-current-copyright-year.sh
+++ b/hack/linters/replace-with-current-copyright-year.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/hack/linters/shellcheck.sh
+++ b/hack/linters/shellcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/hack/linters/yamllint.sh
+++ b/hack/linters/yamllint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:gochecknoglobals

--- a/internal/server/heathcheck_server.go
+++ b/internal/server/heathcheck_server.go
@@ -1,4 +1,4 @@
-// Copyright 2025-2026 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package server

--- a/internal/server/heathcheck_server_test.go
+++ b/internal/server/heathcheck_server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/trento-project/mcp-server/internal/utils"
 )
 
+//nolint:goconst
 func TestHealthCheckers(t *testing.T) {
 	t.Parallel()
 
@@ -96,6 +97,7 @@ func TestHealthCheckers(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestCheckAPIServiceHealth(t *testing.T) {
 	t.Parallel()
 
@@ -261,6 +263,7 @@ func TestStartHealthServer(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestCreateOASPathHealthChecks(t *testing.T) {
 	t.Parallel()
 
@@ -420,6 +423,7 @@ func TestCreateOASPathHealthChecks(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestCreateSingleOASHealthCheck(t *testing.T) {
 	t.Parallel()
 
@@ -652,6 +656,7 @@ func TestCreateSingleOASHealthCheck(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestCheckMCPServer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/heathcheck_server_test.go
+++ b/internal/server/heathcheck_server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:lll

--- a/internal/server/mcp_server.go
+++ b/internal/server/mcp_server.go
@@ -1,4 +1,4 @@
-// Copyright 2025-2026 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package server

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/trento-project/mcp-server/internal/utils"
 )
 
-//nolint:dupl
+//nolint:dupl,goconst
 func TestStartSSEServer(t *testing.T) {
 	t.Parallel()
 
@@ -73,7 +73,7 @@ func TestStartSSEServer(t *testing.T) {
 	}
 }
 
-//nolint:dupl
+//nolint:dupl,goconst
 func TestStartStreamableHTTPServer(t *testing.T) {
 	t.Parallel()
 
@@ -212,6 +212,7 @@ func TestWithLogger(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestCreateMCPServer(t *testing.T) {
 	t.Parallel()
 
@@ -248,6 +249,7 @@ func TestCreateMCPServer(t *testing.T) {
 	assert.Empty(t, tools.Tools)
 }
 
+//nolint:goconst
 func TestHandleToolsRegistration(t *testing.T) {
 	t.Parallel()
 
@@ -402,6 +404,7 @@ func TestHandleToolsRegistration(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestRegisterToolsFromSpec(t *testing.T) {
 	t.Parallel()
 
@@ -520,6 +523,7 @@ func TestRegisterToolsFromSpec(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestHandleToolsRegistrationWithURL(t *testing.T) {
 	t.Parallel()
 
@@ -586,7 +590,7 @@ func TestHandleToolsRegistrationWithURL(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest
+//nolint:paralleltest,goconst
 func TestHandleMCPServerRun(t *testing.T) {
 	t.Parallel()
 
@@ -945,6 +949,7 @@ func TestSetAPIKeyInContext(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestLoadOpenAPISpec(t *testing.T) {
 	t.Parallel()
 
@@ -1029,6 +1034,7 @@ func TestLoadOpenAPISpec(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestLoadOpenAPISpecFromURL(t *testing.T) {
 	t.Parallel()
 
@@ -1132,6 +1138,7 @@ func TestLoadOpenAPISpecFromURL(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestHandleToolsRegistrationAutodiscovery(t *testing.T) {
 	t.Parallel()
 
@@ -1370,6 +1377,7 @@ func TestHandleToolsRegistrationAutodiscovery(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestHandleToolsRegistrationMixedScenarios(t *testing.T) {
 	t.Parallel()
 
@@ -1446,6 +1454,7 @@ func TestHandleToolsRegistrationMixedScenarios(t *testing.T) {
 	}
 }
 
+//nolint:goconst
 func TestServerURLBehavior(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025-2026 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:lll

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package server is the where the server logic is implemented.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025-2026 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package server_test is the where the server logic is tested.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -32,7 +32,7 @@ func waitForShutdownSingle(ctx context.Context, t *testing.T, srv utils.Stoppabl
 	return server.WaitForShutdown(ctx, serverGroup, serverErrChan)
 }
 
-//nolint:paralleltest
+//nolint:paralleltest,goconst
 func TestServe(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -105,7 +105,7 @@ func TestServe(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest
+//nolint:paralleltest,goconst
 func TestWaitForShutdown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/utils/logger.go
+++ b/internal/utils/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // Package utils implements extra functionality like logging.

--- a/internal/utils/logger_test.go
+++ b/internal/utils/logger_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:tparallel,paralleltest
+//nolint:tparallel,paralleltest,goconst
 package utils_test
 
 import (

--- a/internal/utils/logger_test.go
+++ b/internal/utils/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:tparallel,paralleltest

--- a/internal/utils/types.go
+++ b/internal/utils/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package utils //nolint:revive

--- a/internal/utils/types_test.go
+++ b/internal/utils/types_test.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:goconst
 package utils_test
 
 import (

--- a/internal/utils/types_test.go
+++ b/internal/utils/types_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package utils_test

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2026 SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2026 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 package utils //nolint:revive
 
 import (

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2026 SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2026 SUSE LLC
-// SPDX-License-Identifier: Apache-2.0
-
 package utils_test
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 // main package for this project.

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 SUSE LLC
+// SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025-2026 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # Note: This file should be the same as the one in the root of the repository

--- a/packaging/suse/rpm/mcp-server-trento.spec
+++ b/packaging/suse/rpm/mcp-server-trento.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package mcp-server-trento
 #
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 #
 # All modifications and additions to the file contributed by third parties

--- a/packaging/suse/rpm/systemd/mcp-server-trento.example
+++ b/packaging/suse/rpm/systemd/mcp-server-trento.example
@@ -1,4 +1,4 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # Trento MCP Server Configuration File

--- a/packaging/suse/rpm/systemd/mcp-server-trento.service
+++ b/packaging/suse/rpm/systemd/mcp-server-trento.service
@@ -1,4 +1,4 @@
-# Copyright 2025 SUSE LLC
+# SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
 [Unit]


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Related https://github.com/trento-project/web/pull/4237

Related # TRNT-4358

## How was this tested?

License linter.