### PR TITLE
Fix unhandled array parameters

### DIFF
--- a/internal/server/mcp_server.go
+++ b/internal/server/mcp_server.go
@@ -218,6 +218,45 @@ func handleToolsRegistration(
 	return srv, allTools, nil
 }
 
+// FixArrayQueryParameters corrects array query parameters from stringified format to exploded format.
+// TODO(TRNT-4420): this fix belongs to openapi-mcp library, but in the meantime we apply it here
+//
+// Query parameters default to style=form with explode=true, which means:
+// - Correct format: severity=debug&severity=info&severity=warning&severity=critical
+// - Incorrect format: severity=%5Bdebug+info+warning+critical%5D (stringified as [debug info warning critical])
+//
+// Examples:
+// - Input (wrong):  severity=%5Bdebug+info+warning+critical%5D
+// - Output (fixed): severity=debug&severity=info&severity=warning&severity=critical
+//
+// See https://spec.openapis.org/oas/latest#style-examples
+func FixArrayQueryParameters(u *url.URL) {
+	query := u.Query()
+	newQuery := url.Values{}
+
+	for key, values := range query {
+		// Check if this is a single value that looks like a stringified array: [value1 value2 value3]
+		if len(values) == 1 && strings.HasPrefix(values[0], "[") && strings.HasSuffix(values[0], "]") {
+			// Remove the brackets and split by whitespace
+			content := strings.TrimPrefix(strings.TrimSuffix(values[0], "]"), "[")
+			if content != "" {
+				// Split by whitespace and add as exploded parameters
+				items := strings.FieldsSeq(content)
+				for item := range items {
+					newQuery.Add(key, item)
+				}
+			}
+		} else {
+			// Keep non-array parameters as-is
+			for _, v := range values {
+				newQuery.Add(key, v)
+			}
+		}
+	}
+
+	u.RawQuery = newQuery.Encode()
+}
+
 func registerToolsFromSpec(srv *mcp.Server, oasDoc *openapi3.T, serveOpts *ServeOptions) []string {
 	// Extract the API operations.
 	operations := openapi2mcp.ExtractOpenAPIOperations(oasDoc)
@@ -271,6 +310,10 @@ func registerToolsFromSpec(srv *mcp.Server, oasDoc *openapi3.T, serveOpts *Serve
 			if err != nil {
 				return nil, err
 			}
+
+			// Fix array query parameters that openapi-mcp encodes incorrectly
+			// Converts stringified format [value1 value2] to exploded format value1&param=value2
+			FixArrayQueryParameters(req.URL)
 
 			// Use the client's transport RoundTrip to avoid opaque Do sinks and automatic redirects.
 			transport := httpClient.Transport

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -1602,6 +1602,8 @@ func createOASContentWithServer(t *testing.T, operationID, tag, serverURL string
 // See https://spec.openapis.org/oas/latest#style-examples
 // TODO(TRNT-4420): the openapi-mcp library should support all styles/explode combinations,
 // but currently we added FixArrayQueryParameters to convert to exploded format before reaching the upstream API.
+//
+//nolint:goconst
 func TestComplexQueryParameters(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/mcp_server_test.go
+++ b/internal/server/mcp_server_test.go
@@ -1597,3 +1597,221 @@ func createOASContentWithServer(t *testing.T, operationID, tag, serverURL string
 	}
 }`, tag, serverURL, operationID, tag, tag)
 }
+
+// TestComplexQueryParameters ensures the serialization for query parameters is the proper one.
+// See https://spec.openapis.org/oas/latest#style-examples
+// TODO(TRNT-4420): the openapi-mcp library should support all styles/explode combinations,
+// but currently we added FixArrayQueryParameters to convert to exploded format before reaching the upstream API.
+func TestComplexQueryParameters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		arrayParamValues []string
+		style            string // empty = default (form), "spaceDelimited", "pipeDelimited", "deepObject"
+		explode          *bool  // nil = default (true)
+		expectedRawQuery string
+	}{
+		// Array serialization - default style/explode cases (form + explode=true)
+		{
+			name:             "array form explode=true - multiple values",
+			arrayParamValues: []string{"debug", "info", "warning", "critical"},
+			expectedRawQuery: "severity=debug&severity=info&severity=warning&severity=critical",
+		},
+		{
+			name:             "array form explode=true - single value",
+			arrayParamValues: []string{"error"},
+			expectedRawQuery: "level=error",
+		},
+		// Array serialization - other styles (regression tests: openapi-mcp currently encodes all as form+explode=true)
+		{
+			name:             "array form explode=false (currently: form explode=true, future: comma-separated)",
+			arrayParamValues: []string{"blue", "black", "brown"},
+			style:            "form",
+			explode:          ptr(false),
+			expectedRawQuery: "color=blue&color=black&color=brown", // TODO: change to "color=blue,black,brown" when supported
+		},
+		{
+			name:             "array spaceDelimited (currently: form explode=true, future: space-separated)",
+			arrayParamValues: []string{"blue", "black", "brown"},
+			style:            "spaceDelimited",
+			expectedRawQuery: "color=blue&color=black&color=brown", // TODO: change to "color=blue%20black%20brown" when supported
+		},
+		{
+			name:             "array pipeDelimited (currently: form explode=true, future: pipe-separated)",
+			arrayParamValues: []string{"blue", "black", "brown"},
+			style:            "pipeDelimited",
+			expectedRawQuery: "color=blue&color=black&color=brown", // TODO: change to "color=blue%7Cblack%7Cbrown" when supported
+		},
+		{
+			name:             "array spaceDelimited explode=true (spec: n/a, currently: form explode=true)",
+			arrayParamValues: []string{"blue", "black", "brown"},
+			style:            "spaceDelimited",
+			explode:          ptr(true),
+			expectedRawQuery: "color=blue&color=black&color=brown", // Undefined by spec, handled as form explode=true
+		},
+		{
+			name:             "array pipeDelimited explode=true (spec: n/a, currently: form explode=true)",
+			arrayParamValues: []string{"blue", "black", "brown"},
+			style:            "pipeDelimited",
+			explode:          ptr(true),
+			expectedRawQuery: "color=blue&color=black&color=brown", // Undefined by spec, handled as form explode=true
+		},
+		// Object serialization (passed as arrays, openapi-mcp encodes as form+explode=true)
+		{
+			name:             "object form explode=true - key-value pairs",
+			arrayParamValues: []string{"R", "100", "G", "200", "B", "150"},
+			style:            "form",
+			explode:          ptr(true),
+			expectedRawQuery: "color=R&color=100&color=G&color=200&color=B&color=150",
+		},
+		{
+			name:             "object form explode=false (currently: form explode=true, future: comma-separated)",
+			arrayParamValues: []string{"R", "100", "G", "200", "B", "150"},
+			style:            "form",
+			explode:          ptr(false),
+			expectedRawQuery: "color=R&color=100&color=G&color=200&color=B&color=150", // TODO: change to "color=R,100,G,200,B,150" when supported
+		},
+		{
+			name:             "object spaceDelimited (currently: form explode=true, future: space-separated)",
+			arrayParamValues: []string{"R", "100", "G", "200"},
+			style:            "spaceDelimited",
+			expectedRawQuery: "color=R&color=100&color=G&color=200", // TODO: change to "color=R%20100%20G%20200" when supported
+		},
+		{
+			name:             "object pipeDelimited (currently: form explode=true, future: pipe-separated)",
+			arrayParamValues: []string{"R", "100", "G", "200"},
+			style:            "pipeDelimited",
+			expectedRawQuery: "color=R&color=100&color=G&color=200", // TODO: change to "color=R%7C100%7CG%7C200" when supported
+		},
+		{
+			name:             "object spaceDelimited explode=true (spec: n/a, currently: form explode=true)",
+			arrayParamValues: []string{"R", "100", "G", "200"},
+			style:            "spaceDelimited",
+			explode:          ptr(true),
+			expectedRawQuery: "color=R&color=100&color=G&color=200", // Undefined by spec, handled as form explode=true
+		},
+		{
+			name:             "object pipeDelimited explode=true (spec: n/a, currently: form explode=true)",
+			arrayParamValues: []string{"R", "100", "G", "200"},
+			style:            "pipeDelimited",
+			explode:          ptr(true),
+			expectedRawQuery: "color=R&color=100&color=G&color=200", // Undefined by spec, handled as form explode=true
+		},
+		{
+			name:             "object deepObject (currently: form explode=true, future: bracket notation)",
+			arrayParamValues: []string{"R", "100", "G", "200"},
+			style:            "deepObject",
+			expectedRawQuery: "color=R&color=100&color=G&color=200", // TODO: change to "color%5BR%5D=100&color%5BG%5D=200" when supported
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			toolName := strings.ReplaceAll(tt.name, " ", "_")
+
+			// Extract parameter name from expectedRawQuery (the part before the first '=')
+			paramName, _, _ := strings.Cut(tt.expectedRawQuery, "=")
+
+			var capturedRequest *http.Request
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedRequest = r.Clone(r.Context())
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data": []}`))
+			}))
+			defer mockServer.Close()
+
+			// Build OAS content as a complete JSON object (no tabs)
+			paramDef := fmt.Sprintf(`{"name":"%s","in":"query"`, paramName)
+			if tt.style != "" {
+				paramDef += fmt.Sprintf(`,"style":"%s"`, tt.style)
+			}
+			if tt.explode != nil {
+				paramDef += fmt.Sprintf(`,"explode":%v`, *tt.explode)
+			}
+			paramDef += `,"schema":{"type":"array","items":{"type":"string"}}}`
+
+			oasContent := fmt.Sprintf(`
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Test API", "version": "1.0.0"},
+  "servers": [{ "url": "%s" }],
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "%s",
+        "tags": ["Test"],
+        "parameters": [%s],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
+    }
+  }
+}
+`, mockServer.URL, toolName, paramDef)
+
+			tmpFile := createTempOASFile(t, oasContent)
+			srv := server.CreateMCPServer(t.Context(), &server.ServeOptions{Name: "test", Version: "v1"})
+			serveOpts := &server.ServeOptions{
+				Name:      "test-server",
+				Version:   "1.0.0",
+				OASPath:   []string{tmpFile},
+				TrentoURL: mockServer.URL,
+			}
+
+			srv, tools, err := server.HandleToolsRegistration(t.Context(), srv, serveOpts)
+			require.NoError(t, err)
+			require.Contains(t, tools, toolName, "Tool should be registered")
+
+			clientTransport, serverTransport := mcp.NewInMemoryTransports()
+			_, err = srv.Connect(t.Context(), serverTransport, nil)
+			require.NoError(t, err)
+
+			clientImpl := &mcp.Implementation{Name: "test-client", Version: "0.1.0"}
+			client := mcp.NewClient(clientImpl, nil)
+			cs, err := client.Connect(t.Context(), clientTransport, nil)
+			require.NoError(t, err)
+			defer func() { _ = cs.Close() }()
+
+			ctxWithTimeout, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			// Call tool with array parameter
+			result, err := cs.CallTool(ctxWithTimeout, &mcp.CallToolParams{
+				Name: toolName,
+				Arguments: map[string]any{
+					paramName: tt.arrayParamValues,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.False(t, result.IsError)
+
+			require.NotNil(t, capturedRequest, tt.name)
+
+			// Validate query string doesn't contain stringified array format
+			rawQuery := capturedRequest.URL.RawQuery
+			require.NotContains(t, rawQuery, "%5B", "Should not contain encoded [")
+			require.NotContains(t, rawQuery, "%5D", "Should not contain encoded ]")
+			require.NotContains(t, rawQuery, "[", "Should not contain [")
+			require.NotContains(t, rawQuery, "]", "Should not contain ]")
+			require.Contains(t, rawQuery, tt.expectedRawQuery, "Query should match expected format")
+
+			// Validate array values are present in query
+			queryValues := capturedRequest.URL.Query()
+			actualArrayValues := queryValues[paramName]
+			require.Equal(t, tt.arrayParamValues, actualArrayValues, "Array parameter values should match")
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
# Description

The MCP server was receiving HTTP 500 errors from the Activity Log API because openapi-mcp incorrectly serializes array query parameters as stringified format `severity=%5Bdebug+info+warning+critical%5D` instead of the OpenAPI 3.0 spec-compliant exploded format `severity=debug&severity=info&severity=warning&severity=critical`.

This PRs adds a local hotfix in the `RequestHandler` via `FixArrayQueryParameters()` to normalize these parameters.

For example, a possible query: `https://demo.trento-project.io/api/v1/activity_log?last=50&severity=debug&severity=info&severity=warning&severity=critical`

When openapi-mcp is upgraded to properly support alternative serialization styles, the TODO comments in each regression test indicate the expected format to update to:

- `form+explode=false` → `color=blue,black,brown`
- `spaceDelimited` → `color=blue%20black%20brown`  
- `pipeDelimited` → `color=blue%7Cblack%7Cbrown`
- `deepObject` → `color%5BR%5D=100&color%5BG%5D=200&color%5BB%5D=150`

Fixes # TRNT-4420

Related https://github.com/trento-project/web/pull/4299

## How was this tested?

Unit test, see [test before the fix](https://github.com/trento-project/mcp-server/actions/runs/26393805278?pr=123) and [after the fix](https://github.com/trento-project/mcp-server/actions/runs/26394179470/job/77690780431).

## Additional information

This fix actually belongs to the `openapi-mcp` library that we use. ~Will submit the fix upstream shortly.~

A fix has been sent upstream: https://github.com/evcc-io/openapi-mcp/pull/7