### PR TITLE
Remove go patch version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/trento-project/mcp-server
 
-go 1.26.5
+go 1.26
 
 require (
 	github.com/alexliesenfeld/health v0.8.1


### PR DESCRIPTION
# Description

Following up on https://github.com/trento-project/mcp-server/pull/124#pullrequestreview-4805755209, this PR removes the constraint on the patch version used in the go.mod file

This is to fix this OBS error:

```console
ERROR:obs-service-go_modules:go: go.mod requires go >= 1.26.5 (running go 1.26.2; GOTOOLCHAIN=local)
```
## How was this tested?

N/A